### PR TITLE
[DEM-738] qiskit backend change to allow re-use of classical bits

### DIFF
--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -274,11 +274,7 @@ class QuantumInspireBackend(BaseBackend):
         measurements = [[number_of_qubits - 1 - m.qubits[0],
                          number_of_clbits - 1 - m.memory[0]]
                         for m in operations if m.name == 'measure']
-        if measurements:
-            used_classical_bits = [item[1] for item in measurements]
-            if any([bit for bit in used_classical_bits if used_classical_bits.count(bit) > 1]):
-                raise QisKitBackendError("Classical bit is used to measure multiple qubits!")
-        else:
+        if not measurements:
             measurements = [[index, index] for index in range(number_of_qubits)]
         return {'measurements': measurements, 'number_of_clbits': number_of_clbits}
 

--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -288,7 +288,7 @@ class QuantumInspireBackend(BaseBackend):
             Args:
                 result (dict): The result output from the quantum inspire backend with full-
                                state projection histogram output.
-                measurements (dict): Measured qubits/classical bits map and number of classical bits
+                measurements (list): Measured qubits/classical bits map and number of classical bits
                 number_of_qubits (int): number of qubits used in the algorithm
                 number_of_shots (int): The number of times the algorithm is executed.
 

--- a/src/tests/quantuminspire/qiskit/test_backend_qx.py
+++ b/src/tests/quantuminspire/qiskit/test_backend_qx.py
@@ -346,20 +346,19 @@ class TestQiSimulatorPyHistogram(unittest.TestCase):
         )
 
     def test_convert_histogram_ClassicalBitsMeasureSameQubits(self):
-        with self.assertRaisesRegex(QisKitBackendError, 'Classical bit is used to measure multiple qubits!'):
-            self.run_histogram_test(
-                single_experiment={'instructions': [{'name': 'h', 'params': [], 'texparams': [], 'qubits': [0]},
-                                                    {'name': 'cx', 'params': [], 'texparams': [], 'qubits': [0, 1]},
-                                                    {'name': 'measure', 'qubits': [0], 'memory': [0]},
-                                                    {'name': 'measure', 'qubits': [1], 'memory': [0]}],
-                                   'header': {'n_qubits': 2, 'memory_slots': 2, 'name': 'test',
-                                              'qubit_labels': [['q0', 0], ['q0', 1]],
-                                              'clbit_labels': [['c0', 0], ['c1', 1]]}
-                                   },
-                mock_result={'histogram': {'0': 0.1, '1': 0.2, '2': 0.3, '3': 0.4}, 'execution_time_in_seconds': 2.1,
-                             'n_qubits': 2},
-                expected_histogram=None
-            )
+        self.run_histogram_test(
+            single_experiment={'instructions': [{'name': 'h', 'params': [], 'texparams': [], 'qubits': [0]},
+                                                {'name': 'cx', 'params': [], 'texparams': [], 'qubits': [0, 1]},
+                                                {'name': 'measure', 'qubits': [0], 'memory': [0]},
+                                                {'name': 'measure', 'qubits': [1], 'memory': [0]}],
+                               'header': {'n_qubits': 2, 'memory_slots': 2, 'name': 'test',
+                                          'qubit_labels': [['q0', 0], ['q0', 1]],
+                                          'clbit_labels': [['c0', 0], ['c1', 1]]}
+                               },
+            mock_result={'histogram': {'0': 0.1, '1': 0.2, '2': 0.3, '3': 0.4}, 'execution_time_in_seconds': 2.1,
+                         'number_of_qubits': 2},
+            expected_histogram={'0x0': 300, '0x1': 700}
+        )
 
     def test_empty_histogram(self):
         with self.assertRaises(QisKitBackendError) as error:
@@ -370,7 +369,7 @@ class TestQiSimulatorPyHistogram(unittest.TestCase):
                       'texparams': [], 'qubits': [0, 1]},
                      {'name': 'measure', 'qubits': [1], 'memory': [1]}]),
                 mock_result={'histogram': {}, 'execution_time_in_seconds': 2.1,
-                             'n_qubits': 2, 'raw_text': 'oopsy daisy'},
+                             'number_of_qubits': 2, 'raw_text': 'oopsy daisy'},
                 expected_histogram={}
             )
         self.assertEqual(('Result from backend contains no histogram data!\noopsy daisy',), error.exception.args)


### PR DESCRIPTION
The following piece of code is allowed now (notice the measurement in cr1[0] for both qubits):
{code}
        circ1 = QuantumCircuit(qr1, qr2, cr1, cr2)
        circ1.h(qr1[0])
        circ1.h(qr2[0])
        circ1.measure(qr1[0], cr1[0])
        circ1.h(qr2[0])
        circ1.measure(qr2[0], cr1[0])
{code}
