### PR TITLE
[DEM-735] implementation of full state histogram

### DIFF
--- a/docs/example_qiskit_entangle.py
+++ b/docs/example_qiskit_entangle.py
@@ -15,6 +15,7 @@ Copyright 2018-19 QuTech Delft. Licensed under the Apache License, Version 2.0.
 """
 from getpass import getpass
 
+from qiskit.validation.base import Obj
 from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.tools.compiler import execute
 
@@ -50,3 +51,9 @@ if __name__ == '__main__':
     histogram = qi_result.get_counts(circuit)
     print('\nState\tCounts')
     [print('{0}\t{1}'.format(state, counts)) for state, counts in histogram.items()]
+    # Print the full state probabilities histogram
+    probabilities_histogram = Obj.to_dict(qi_result.data(circuit)['probabilities'])
+    print('\nState\tProbabilities')
+    # Format the hexadecimal key to a zero-padded binary string with length of the number of classical bits
+    [print('{0}\t{1}'.format(format(int(str(bin(int(key, 16)))[2:], 2), '0{}b'.format(b.size)),
+                             val)) for key, val in probabilities_histogram.items()]


### PR DESCRIPTION
Realisation to view the QI histogram in the result. This histogram exists of probabilities for the states after the 'translation' of the qubit registers to classical bit measurements, so for the Qiskit user it is clear what the probabilities are representing.
I asked the Qiskit people where to put these probability-results and they said to put it in probabilites under result.data, so result.data.probabilities.
Within the unittests of this tickets, the probabilities are checked against the expected probabilities. Meaning floating point comparison, meaning carefulness. I used isclose() from numpy to check equality of floats.