### PR TITLE
fixed the gates u3, u2, u1 and u

### DIFF
--- a/src/quantuminspire/qiskit/circuit_parser.py
+++ b/src/quantuminspire/qiskit/circuit_parser.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 """
-
+import copy
 import numpy as np
 
 
@@ -150,7 +150,8 @@ class CircuitToString:
         return None
 
     def _u1(self, circuit):
-        """ Translates the U1(lambda) element to U3(0, 0, lambda).
+        """ Translates the U1(lambda) element to U3(0, 0, lambda). A copy of the circuit is made to prevent
+            side-effects for the caller.
 
         Args:
             circuit (dict): The Qiskit circuit with U1 element.
@@ -158,21 +159,20 @@ class CircuitToString:
         Returns:
             str: cQASM code string.
         """
-        tempcircuit = circuit
-        tempcircuit['params'].insert(0, 0)
-        tempcircuit['params'].insert(0, 0)
-        tempcircuit['texparams'].insert(0, '0')
-        tempcircuit['texparams'].insert(0, '0')
+        tempcircuit = copy.deepcopy(circuit)
+        tempcircuit['params'][0:0] = (0, 0)
+        tempcircuit['texparams'][0:0] = ('0', '0')
         return self._u3(tempcircuit)
 
     def _u2(self, circuit):
-        """ Translates the U2(phi, lambda) element to U3(pi/2, phi, lambda).
+        """ Translates the U2(phi, lambda) element to U3(pi/2, phi, lambda). A copy of the circuit is made to prevent
+            side-effects for the caller.
 
         Args:
             circuit (dict): The Qiskit circuit with U2 element.
 
         """
-        tempcircuit = circuit
+        tempcircuit = copy.deepcopy(circuit)
         tempcircuit['params'].insert(0, np.pi/2)
         tempcircuit['texparams'].insert(0, '\\frac{\\pi}{2}')
         return self._u3(tempcircuit)


### PR DESCRIPTION
In this change the circuit u3, u2, u1 and u are fixed.
u3 was wrong in 2 ways, the parameter for the Ry gate is the first. Also the gates must be added in reversed order to match the matrix multiplication for u3 (U3(theta, phi, lambda) = Rz(phi)Ry(theta)Rz(lambda))
u2 and u1 were only defined for a number of fixed rotations. With the fix of u3 now all rotations for these gates are supported because U1(lambda) = U3(0, 0, lambda) and U2(phi, lambda) = U3(pi/2, phi, lambda).
The u gate is equal to the u3 gate.
When u1 and u2 are transformed to a call for u3, parameters are added  in both params and texparams fields of the circuit (a temporary so no effect on the caller). Within _u3 there is no difference if the call was directly from a u3 gate or a transformed u2/u1.

The unit tests have been adjusted for these changes.