### PR TITLE
Generating count histogram from the raw data

### DIFF
--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -18,7 +18,8 @@ limitations under the License.
 import io
 import json
 import uuid
-from collections import defaultdict, OrderedDict
+import numpy as np
+from collections import defaultdict, OrderedDict, Counter
 
 from coreapi.exceptions import ErrorMessage
 from qiskit.providers import BaseBackend
@@ -106,8 +107,7 @@ class QuantumInspireBackend(BaseBackend):
         return job
 
     def retrieve_job(self, job_id):
-        """
-        Retrieve a specified job by its job_id.
+        """ Retrieve a specified job by its job_id.
 
         Args:
             job_id (str): The job id.
@@ -160,8 +160,8 @@ class QuantumInspireBackend(BaseBackend):
         return job_id
 
     def get_experiment_results(self, qi_job):
-        """
-        Get results from experiments from the Quantum-inspire platform.
+        """ Get results from experiments from the Quantum-inspire platform.
+
         Args:
             qi_job (QIJob): A job that has already been submitted and which execution is completed.
 
@@ -169,7 +169,7 @@ class QuantumInspireBackend(BaseBackend):
             QisKitBackendError: If an error occurred during execution by the backend.
 
         Returns:
-            List: A list of experiment results; containing the data, execution time, status, etc.
+            list: A list of experiment results; containing the data, execution time, status, etc.
         """
         jobs = self.__api.get_jobs_from_project(qi_job.job_id())
         results = [self.__api.get(job['results']) for job in jobs]
@@ -181,20 +181,11 @@ class QuantumInspireBackend(BaseBackend):
 
             user_data = json.loads(job.get('user_data'))
             measurements = user_data.pop('measurements')
-            histogram, full_state_histogram = QuantumInspireBackend.__convert_histograms(result, measurements,
-                                                                                         result['number_of_qubits'],
-                                                                                         job['number_of_shots'])
-            histogram_obj = Obj.from_dict(histogram)
-            full_state_histogram_obj = Obj.from_dict(full_state_histogram)
-            raw_data = self.__api.get_raw_data(str(result['id']))
-            memory_data = self.__get_memory_data(raw_data, measurements, result['number_of_qubits'])
-            if memory_data:
-                experiment_result_data = ExperimentResultData(counts=histogram_obj,
-                                                              probabilities=full_state_histogram_obj,
-                                                              memory=memory_data)
-            else:
-                experiment_result_data = ExperimentResultData(counts=histogram_obj,
-                                                              probabilities=full_state_histogram_obj)
+            histogram_obj, memory_data = self.__convert_result_data(result, measurements)
+            full_state_histogram_obj = self.__convert_histogram(result, measurements)
+            experiment_result_data = ExperimentResultData(counts=histogram_obj,
+                                                          probabilities=full_state_histogram_obj,
+                                                          memory=memory_data)
             header = Obj.from_dict(user_data)
             experiment_result_dictionary = {'name': job.get('name'), 'seed': 42, 'shots': job.get('number_of_shots'),
                                             'data': experiment_result_data, 'status': 'DONE', 'success': True,
@@ -270,7 +261,7 @@ class QuantumInspireBackend(BaseBackend):
             experiment (QobjExperiment): The experiment with gate operations and header.
 
         Returns:
-            List: A list of lists, for each measurement the returned list contains a list of
+            list: A list of lists, for each measurement the returned list contains a list of
                   [qubit_index, classical_bit_index], which represents the measurement of a qubit to a classical bit.
         """
         header = experiment.header
@@ -308,58 +299,84 @@ class QuantumInspireBackend(BaseBackend):
         return classical_state_hex
 
     @staticmethod
-    def __get_memory_data(raw_data, measurements, number_of_qubits):
-        """ The quantum inspire backend returns the single shot values. This function
-            converts the raw data to hexadecimal memory data according the Qiskit spec.
-
-        Note:
-            When shots = 1, the backend returns an empty list as raw_data.
-
-        Args:
-            raw_data (list): The raw data output from the quantum inspire backend with the
-                             data for each shot.
-            measurements (dict): The dictionary contains a measured qubits/classical bits map (list) and the
-                                 number of classical bits (int).
-            number_of_qubits (int): Number of qubits used in the algorithm.
-
-        Returns:
-            List: The result with converted hexadecimal memory values for each shot
-                  or an empty list when no raw_data was returned by the backend.
-        """
-        memory_data = []
-        for qubit_register in raw_data:
-            classical_state_hex = QuantumInspireBackend.__qubit_to_classical_hex(qubit_register, measurements,
-                                                                                 number_of_qubits)
-            memory_data.append(classical_state_hex)
-        return memory_data
-
-    @staticmethod
-    def __convert_histograms(result, measurements, number_of_qubits, number_of_shots):
+    def __convert_histogram(result, measurements):
         """ The quantum inspire backend always uses full state projection. The SDK user
             can measure not all qubits and change the combined classical bits. This function
-            converts the result to two histogram outputs: one that represents the counts
-            measured with the classical bits and a second histogram that represents the
-            probabilities measured with the classical bits.
+            converts the result to a histogram output that represents the probabilities
+            measured with the classical bits.
 
-            Args:
-                result (dict): The result output from the quantum inspire backend with full-
-                               state projection histogram output.
-                measurements (dict): The dictionary contains a measured qubits/classical bits map (list) and the
-                                     number of classical bits (int).
-                number_of_qubits (int): Number of qubits used in the algorithm.
-                number_of_shots (int): The number of times the algorithm is executed.
+        Args:
+            result (dict): The result output from the quantum inspire backend with full-
+                           state projection histogram output.
+            measurements (dict): The dictionary contains a measured qubits/classical bits map (list) and the
+                                 number of classical bits (int).
 
-            Returns:
-                (Dict, Dict): The result with 2 converted histograms. One with counts and one with probabilities
+        Returns:
+            (Obj): The resulting full state histogram with probabilities.
         """
-        output_histogram_counts = defaultdict(lambda: 0)
         output_histogram_probabilities = defaultdict(lambda: 0)
+        number_of_qubits = result['number_of_qubits']
         state_probability = result['histogram']
         for qubit_register, probability in state_probability.items():
             classical_state_hex = QuantumInspireBackend.__qubit_to_classical_hex(qubit_register, measurements,
                                                                                  number_of_qubits)
-            output_histogram_counts[classical_state_hex] += int(probability * number_of_shots)
             output_histogram_probabilities[classical_state_hex] += probability
 
-        return (OrderedDict(sorted(output_histogram_counts.items(), key=lambda kv: int(kv[0], 16))),
-                OrderedDict(sorted(output_histogram_probabilities.items(), key=lambda kv: int(kv[0], 16))))
+        full_state_histogram_obj = OrderedDict(sorted(output_histogram_probabilities.items(),
+                                                      key=lambda kv: int(kv[0], 16)))
+        return Obj.from_dict(full_state_histogram_obj)
+
+    def __convert_result_data(self, result, measurements):
+        """ The quantum inspire backend returns the single shot values as raw data. This function
+            converts this list of single shot values to hexadecimal memory data according the Qiskit spec.
+            From this memory data the counts histogram is constructed by counting the single shot values.
+
+        Note:
+            When shots = 1, the backend returns an empty list as raw_data. This is a special case. In this case the
+            resulting memory data consists of 1 value and the count histogram consists of 1 instance of this value.
+            To determine this value a random float is generated in the range [0, 1). With this random number the
+            value from this probabilities histogram is taken where the added probabilities is greater this random
+            number.
+            Example: probability histogram is {[0x0, 0.2], [0x3, 0.4], [0x5, 0.1], [0x6, 0.3]}.
+            When random is in the range [0, 0.2) the first value of the probability histogram is taken (0x0).
+            When random is in the range [0.2, 0.6) the second value of the probability histogram is taken (0x3).
+            When random is in the range [0.6, 0.7) the third value of the probability histogram is taken (0x5).
+            When random is in the range [0.7, 1) the last value of the probability histogram is taken (0x6).
+
+        Args:
+            result (dict): The result output from the quantum inspire backend with full-
+                           state projection histogram output.
+            measurements (dict): The dictionary contains a measured qubits/classical bits map (list) and the
+                                 number of classical bits (int).
+
+        Returns:
+            (Obj, list): The result consists of two formats for the result. The first result is the histogram with
+                         count data, the second result is a list with converted hexadecimal memory values for
+                         each shot.
+        """
+        memory_data = []
+        histogram_data = defaultdict(lambda: 0)
+        number_of_qubits = result['number_of_qubits']
+        raw_data = self.__api.get_raw_data(str(result['id']))
+        if raw_data:
+            for qubit_register in raw_data:
+                classical_state_hex = QuantumInspireBackend.__qubit_to_classical_hex(qubit_register, measurements,
+                                                                                     number_of_qubits)
+                memory_data.append(classical_state_hex)
+            for elem, count in Counter(memory_data).items():
+                histogram_data[elem] = count
+        else:
+            state_probabilities = result['histogram']
+            prob = np.random.rand()
+            sum_probability = 0.0
+            for qubit_register, probability in state_probabilities.items():
+                sum_probability += probability
+                if prob < sum_probability:
+                    classical_state_hex = QuantumInspireBackend.__qubit_to_classical_hex(qubit_register, measurements,
+                                                                                         number_of_qubits)
+                    memory_data.append(classical_state_hex)
+                    histogram_data[classical_state_hex] = 1
+                    break
+
+        histogram_obj = OrderedDict(sorted(histogram_data.items(), key=lambda kv: int(kv[0], 16)))
+        return Obj.from_dict(histogram_obj), memory_data

--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -19,7 +19,7 @@ import io
 import json
 import uuid
 import numpy as np
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Any
 from collections import defaultdict, OrderedDict, Counter
 
 from coreapi.exceptions import ErrorMessage
@@ -36,7 +36,6 @@ from quantuminspire.qiskit.qi_job import QIJob
 from quantuminspire.version import __version__ as quantum_inspire_version
 from quantuminspire.job import QuantumInspireJob
 from quantuminspire.api import QuantumInspireAPI
-from quantuminspire.qiskit.quantum_inspire_provider import QuantumInspireProvider
 
 
 class QuantumInspireBackend(BaseBackend):
@@ -54,13 +53,13 @@ class QuantumInspireBackend(BaseBackend):
         max_shots=1024
     )
 
-    def __init__(self, api: QuantumInspireAPI, provider: QuantumInspireProvider,
+    def __init__(self, api: QuantumInspireAPI, provider: Any,
                  configuration: BackendConfiguration = None) -> None:
         """ Python implementation of a quantum simulator using Quantum Inspire API.
 
         Args:
             api: The interface instance to the Quantum Inspire API.
-            provider: Provider for this backend.
+            provider (QuantumInspireProvider): Provider for this backend.
             configuration: The configuration of the quantum inspire backend. The
                 configuration must implement the fields given by the QiSimulatorPy.DEFAULT_CONFIGURATION. All
                 configuration fields are listed in the table below. The table rows with an asterisk specify fields which

--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -36,6 +36,7 @@ from quantuminspire.qiskit.qi_job import QIJob
 from quantuminspire.version import __version__ as quantum_inspire_version
 from quantuminspire.job import QuantumInspireJob
 from quantuminspire.api import QuantumInspireAPI
+from quantuminspire.qiskit.quantum_inspire_provider import QuantumInspireProvider
 
 
 class QuantumInspireBackend(BaseBackend):
@@ -53,14 +54,14 @@ class QuantumInspireBackend(BaseBackend):
         max_shots=1024
     )
 
-    def __init__(self, api: QuantumInspireAPI, provider,
+    def __init__(self, api: QuantumInspireAPI, provider: QuantumInspireProvider,
                  configuration: BackendConfiguration = None) -> None:
         """ Python implementation of a quantum simulator using Quantum Inspire API.
 
         Args:
-            api (QuantumInspireApi): The interface instance to the Quantum Inspire API.
-            provider (QuantumInspireProvider): Provider for this backend.
-            configuration (BackendConfiguration, optional): The configuration of the quantum inspire backend. The
+            api: The interface instance to the Quantum Inspire API.
+            provider: Provider for this backend.
+            configuration: The configuration of the quantum inspire backend. The
                 configuration must implement the fields given by the QiSimulatorPy.DEFAULT_CONFIGURATION. All
                 configuration fields are listed in the table below. The table rows with an asterisk specify fields which
                 can have a custom value and are allowed to be changed according to the description column.
@@ -93,10 +94,10 @@ class QuantumInspireBackend(BaseBackend):
         """ Submits a quantum job to the Quantum Inspire platform.
 
         Args:
-            qobj (Qobj): The quantum job with the Qiskit algorithm and quantum inspire backend.
+            qobj: The quantum job with the Qiskit algorithm and quantum inspire backend.
 
         Returns:
-            QIJob: A job that has been submitted.
+            A job that has been submitted.
         """
         QuantumInspireBackend.__validate(qobj)
         number_of_shots = qobj.config.shots
@@ -114,10 +115,10 @@ class QuantumInspireBackend(BaseBackend):
         """ Retrieve a specified job by its job_id.
 
         Args:
-            job_id (str): The job id.
+            job_id: The job id.
 
         Returns:
-            QIJob: The job that has been retrieved.
+            The job that has been retrieved.
 
         Raises:
             QisKitBackendError: If job not found or error occurs during retrieval of the job.
@@ -133,10 +134,10 @@ class QuantumInspireBackend(BaseBackend):
         """ Generates the cQASM from the Qiskit experiment.
 
         Args:
-            experiment (QobjExperiment): The experiment that contains instructions to be converted to cQASM.
+            experiment: The experiment that contains instructions to be converted to cQASM.
 
         Returns:
-            str: The cQASM code that can be sent to the Quantum Inspire API.
+            The cQASM code that can be sent to the Quantum Inspire API.
         """
         parser = CircuitToString()
         number_of_qubits = experiment.header.n_qubits
@@ -169,13 +170,13 @@ class QuantumInspireBackend(BaseBackend):
         """ Get results from experiments from the Quantum-inspire platform.
 
         Args:
-            qi_job (QIJob): A job that has already been submitted and which execution is completed.
+            qi_job: A job that has already been submitted and which execution is completed.
 
         Raises:
             QisKitBackendError: If an error occurred during execution by the backend.
 
         Returns:
-            list: A list of experiment results; containing the data, execution time, status, etc.
+            A list of experiment results; containing the data, execution time, status, etc.
         """
         jobs = self.__api.get_jobs_from_project(qi_job.job_id())
         results = [self.__api.get(job['results']) for job in jobs]
@@ -204,7 +205,7 @@ class QuantumInspireBackend(BaseBackend):
         """ Validates the number of shots, classical bits and compiled Qiskit circuits.
 
         Args:
-            job (Qobj): The quantum job with the Qiskit algorithm and quantum inspire backend.
+            job: The quantum job with the Qiskit algorithm and quantum inspire backend.
         """
         QuantumInspireBackend.__validate_number_of_shots(job)
 
@@ -217,7 +218,7 @@ class QuantumInspireBackend(BaseBackend):
         """ Checks whether the number of shots has a valid value.
 
         Args:
-            job (Qobj): The quantum job with the Qiskit algorithm and quantum inspire backend.
+            job: The quantum job with the Qiskit algorithm and quantum inspire backend.
 
         Raises:
             QisKitBackendError: When the value is not correct.
@@ -231,7 +232,7 @@ class QuantumInspireBackend(BaseBackend):
         """ Checks whether the number of classical bits has a valid value.
 
         Args:
-            experiment (QobjExperiment): The experiment with gate operations and header.
+            experiment: The experiment with gate operations and header.
 
         Raises:
             QisKitBackendError: When the value is not correct.
@@ -245,7 +246,7 @@ class QuantumInspireBackend(BaseBackend):
         """ Checks whether the number of classical bits has a valid value.
 
         Args:
-            experiment (QobjExperiment): The experiment with gate operations and header.
+            experiment: The experiment with gate operations and header.
 
         Raises:
             QisKitBackendError: When the value is not correct.
@@ -264,12 +265,12 @@ class QuantumInspireBackend(BaseBackend):
             qubits is returned when no measurements are present in the compiled circuit.
 
         Args:
-            experiment (QobjExperiment): The experiment with gate operations and header.
+            experiment: The experiment with gate operations and header.
 
         Returns:
-            dict: The dict contains measurements, which is a list of lists, for each measurement the list contains
-                  a list of [qubit_index, classical_bit_index], which represents the measurement of a qubit to a
-                  classical bit, and the second field in the dict is the number of classical bits (int).
+            The dict contains measurements, which is a list of lists, for each measurement the list contains
+            a list of [qubit_index, classical_bit_index], which represents the measurement of a qubit to a
+            classical bit, and the second field in the dict is the number of classical bits (int).
         """
         header = experiment.header
         number_of_qubits = header.n_qubits
@@ -288,14 +289,13 @@ class QuantumInspireBackend(BaseBackend):
         """ This function converts the qubit register data to the hexadecimal representation of the classical state.
 
         Args:
-            qubit_register (int): The measured value of the qubits represented as int.
-            measurements (dict): The dictionary contains a measured qubits/classical bits map (list) and the
-                                 number of classical bits (int).
-            number_of_qubits (int): Number of qubits used in the algorithm.
+            qubit_register: The measured value of the qubits represented as int.
+            measurements: The dictionary contains a measured qubits/classical bits map (list) and the
+                          number of classical bits (int).
+            number_of_qubits: Number of qubits used in the algorithm.
 
         Returns:
-            str: The hexadecimal value of the classical state.
-
+            The hexadecimal value of the classical state.
         """
         qubit_state = ('{0:0{1}b}'.format(int(qubit_register), number_of_qubits))
         classical_state = ['0'] * measurements['number_of_clbits']
@@ -313,13 +313,13 @@ class QuantumInspireBackend(BaseBackend):
             measured with the classical bits.
 
         Args:
-            result (dict): The result output from the quantum inspire backend with full-
-                           state projection histogram output.
-            measurements (dict): The dictionary contains a measured qubits/classical bits map (list) and the
-                                 number of classical bits (int).
+            result: The result output from the quantum inspire backend with full-
+                    state projection histogram output.
+            measurements: The dictionary contains a measured qubits/classical bits map (list) and the
+                          number of classical bits (int).
 
         Returns:
-            (Obj): The resulting full state histogram with probabilities.
+            The resulting full state histogram with probabilities.
         """
         output_histogram_probabilities = defaultdict(lambda: 0)
         number_of_qubits = result['number_of_qubits']
@@ -351,15 +351,14 @@ class QuantumInspireBackend(BaseBackend):
             When random is in the range [0.7, 1) the last value of the probability histogram is taken (0x6).
 
         Args:
-            result (dict): The result output from the quantum inspire backend with full-
-                           state projection histogram output.
-            measurements (dict): The dictionary contains a measured qubits/classical bits map (list) and the
-                                 number of classical bits (int).
+            result: The result output from the quantum inspire backend with full-
+                    state projection histogram output.
+            measurements: The dictionary contains a measured qubits/classical bits map (list) and the
+                          number of classical bits (int).
 
         Returns:
-            (Obj, list): The result consists of two formats for the result. The first result is the histogram with
-                         count data, the second result is a list with converted hexadecimal memory values for
-                         each shot.
+            The result consists of two formats for the result. The first result is the histogram with count data,
+            the second result is a list with converted hexadecimal memory values for each shot.
         """
         memory_data = []
         histogram_data = defaultdict(lambda: 0)

--- a/src/quantuminspire/qiskit/quantum_inspire_provider.py
+++ b/src/quantuminspire/qiskit/quantum_inspire_provider.py
@@ -1,8 +1,10 @@
 from copy import copy
+from typing import List, Optional
 
 from coreapi.auth import BasicAuthentication
 from qiskit.providers import BaseProvider
 
+from quantuminspire.qiskit.backend_qx import QuantumInspireBackend
 from quantuminspire.api import QuantumInspireAPI
 from quantuminspire.exceptions import ApiError
 
@@ -12,27 +14,25 @@ QI_URL = 'https://api.quantum-inspire.com'
 class QuantumInspireProvider(BaseProvider):
     """ Provides a backend and an api for a single Quantum Inspire account. """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._backends = []
         self._api = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         return 'QI'
 
-    def backends(self, name=None, **kwargs):
+    def backends(self, name: str = None, **kwargs) -> List[QuantumInspireBackend]:
         """
         Provides a list of backends.
 
         Args:
-            name (str): Name of the requested backend.
-            **kwargs (dict): Used for filtering, not implemented.
+            name: Name of the requested backend.
+            **kwargs: Used for filtering, not implemented.
 
         Returns:
-            list<QuantumInspireBackend>: List of backends that meet the filter requirements.
+            List of backends that meet the filter requirements.
         """
-        from quantuminspire.qiskit.backend_qx import QuantumInspireBackend
-
         if self._api is None:
             raise ApiError('Authentication details have not been set.')
 
@@ -48,13 +48,13 @@ class QuantumInspireProvider(BaseProvider):
 
         return backends
 
-    def set_authentication_details(self, email, password, qi_url=None):
+    def set_authentication_details(self, email: str, password: str, qi_url: Optional[str] = None) -> None:
         """
         Set a single authentication for Quantum Inspire.
 
         Args:
-            email (str): A valid email address.
-            password (str): Password for the account.
+            email: A valid email address.
+            password: Password for the account.
             qi_url: Optional URL that points to quantum-inspire api.
 
         """

--- a/src/quantuminspire/qiskit/quantum_inspire_provider.py
+++ b/src/quantuminspire/qiskit/quantum_inspire_provider.py
@@ -5,7 +5,6 @@ from qiskit.providers import BaseProvider
 
 from quantuminspire.api import QuantumInspireAPI
 from quantuminspire.exceptions import ApiError
-from quantuminspire.qiskit.backend_qx import QuantumInspireBackend
 
 QI_URL = 'https://api.quantum-inspire.com'
 
@@ -32,6 +31,8 @@ class QuantumInspireProvider(BaseProvider):
         Returns:
             list<QuantumInspireBackend>: List of backends that meet the filter requirements.
         """
+        from quantuminspire.qiskit.backend_qx import QuantumInspireBackend
+
         if self._api is None:
             raise ApiError('Authentication details have not been set.')
 

--- a/src/quantuminspire/qiskit/quantum_inspire_provider.py
+++ b/src/quantuminspire/qiskit/quantum_inspire_provider.py
@@ -1,5 +1,5 @@
 from copy import copy
-from typing import List, Optional
+from typing import List, Optional, Any
 
 from coreapi.auth import BasicAuthentication
 from qiskit.providers import BaseProvider
@@ -14,7 +14,7 @@ QI_URL = 'https://api.quantum-inspire.com'
 class QuantumInspireProvider(BaseProvider):
     """ Provides a backend and an api for a single Quantum Inspire account. """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._backends = []
         self._api = None
@@ -22,7 +22,7 @@ class QuantumInspireProvider(BaseProvider):
     def __str__(self) -> str:
         return 'QI'
 
-    def backends(self, name: str = None, **kwargs) -> List[QuantumInspireBackend]:
+    def backends(self, name: Optional[str] = None, **kwargs: Any) -> List[QuantumInspireBackend]:
         """
         Provides a list of backends.
 


### PR DESCRIPTION
With this issue, the raw data that is returned from the backend is taken as the source to calculate the count histogram (instead of the probabilities histogram). Also the memory data field is filled with the raw data values.
A special case is when number_of_shots = 1. In this case the backend doesn't return raw_data.
With number_of_shots = 1, there must be one value in the counts histogram (with count = 1), and the same single value in memory data. To determine this value a random float is generated in the range [0, 1). With this random number the value from the probabilities histogram is taken where the added probabilities is greater this random number.

Also the unit tests are adjusted because the single shot unit test now delivers valid data.

Some minor docstring adjustments for the other part of the file.