### PR TITLE
[DEM-811] api._get made private

### DIFF
--- a/src/quantuminspire/api.py
+++ b/src/quantuminspire/api.py
@@ -61,7 +61,7 @@ class QuantumInspireAPI:
                                   Default set to coreapi.Client.
 
         Note: When no project name is given, a temporary project is created for the job and deleted after the job
-              has finished. When a project name is given, a project is created if it does not exists, but re-used
+              has finished. When a project name is given, a project is created if it does not exist, but re-used
               if a project with that name already exists. In either case, the project will not be deleted when a
               project name is supplied here.
 
@@ -76,7 +76,7 @@ class QuantumInspireAPI:
         except (CoreAPIException, TypeError) as ex:
             raise ApiError('Could not connect to {}'.format(base_uri)) from ex
 
-    def get(self, uri_path: str) -> Any:
+    def _get(self, uri_path: str) -> Any:
         """ Method for making requests to the coreapi client instance to get some piece of information. The information
             requested depends on the uri_path parameter.
 
@@ -117,7 +117,7 @@ class QuantumInspireAPI:
 
     def _load_schema(self) -> None:
         """ Loads the schema with metadata that explains how the api-data is structured."""
-        self.document = self.get(urljoin(self.base_uri, 'schema/'))
+        self.document = self._get(urljoin(self.base_uri, 'schema/'))
 
     def list_backend_types(self) -> None:
         """ Prints the backend types with the name and the maximum number of qubits it supports."""
@@ -181,7 +181,7 @@ class QuantumInspireAPI:
             backend_name: The backend name.
 
         Raises:
-            ApiError: An ApiError exception is thrown when the backend name does not exists.
+            ApiError: An ApiError exception is thrown when the backend name does not exist.
 
         Returns:
             The properties of the backend type of the specific backend.
@@ -202,7 +202,7 @@ class QuantumInspireAPI:
             identifier: The backend type identifier.
 
         Raises:
-            ApiError: If the requested backend type does not exists.
+            ApiError: If the requested backend type does not exist.
             ValueError: If the backend type identifier is not of the correct type.
 
         Returns:
@@ -235,7 +235,7 @@ class QuantumInspireAPI:
             project_id: The project identification number.
 
         Raises:
-            ApiError: If the requested project does not exists.
+            ApiError: If the requested project does not exist.
 
         Returns:
             The properties describing the project:
@@ -293,7 +293,7 @@ class QuantumInspireAPI:
             project_id: The project identification number.
 
         Raises:
-            ApiError: If the project identified by project_id does not exists.
+            ApiError: If the project identified by project_id does not exist.
         """
         payload = {
             'id': project_id
@@ -319,7 +319,7 @@ class QuantumInspireAPI:
             job_id: The job identification number.
 
         Raises:
-            ApiError: If the requested job does not exists.
+            ApiError: If the requested job does not exist.
 
         Returns:
             The properties describing the job:
@@ -358,6 +358,26 @@ class QuantumInspireAPI:
         ret: List[Dict[str, Any]] = self._action(['jobs', 'list'])
         return ret
 
+    def get_jobs_from_asset(self, asset_id: int) -> List[Dict[str, Any]]:
+        """ Gets the jobs with its properties for a asset, given the asset id.
+
+        Args:
+            asset_id: The asset identification number.
+
+        Returns:
+            List of jobs with its properties for the asset with identification asset_id.
+            An empty list is returned when the asset has no jobs.
+
+        Raises:
+            ApiError: If the asset identified by asset_id does not exist.
+        """
+        try:
+            jobs = self._action(['assets', 'jobs', 'list'], params={'id': asset_id})
+        except ErrorMessage as err_msg:
+            raise ApiError('Asset with id {} does not exist!'.format(asset_id)) from err_msg
+        ret: List[Dict[str, Any]] = jobs
+        return ret
+
     def get_jobs_from_project(self, project_id: int) -> List[Dict[str, Any]]:
         """ Gets the jobs with its properties for a single project, given the project id.
 
@@ -369,7 +389,7 @@ class QuantumInspireAPI:
             An empty list is returned when the project has no jobs.
 
         Raises:
-            ApiError: If the project identified by project_id does not exists.
+            ApiError: If the project identified by project_id does not exist.
         """
         try:
             jobs = self._action(['projects', 'jobs', 'list'], params={'id': project_id})
@@ -390,7 +410,7 @@ class QuantumInspireAPI:
             See `get_job` for a description of the job properties.
 
         Raises:
-            ApiError: If the job identified by job_id does not exists.
+            ApiError: If the job identified by job_id does not exist.
         """
         try:
             return OrderedDict(self._action(['jobs', 'delete'], params={'id': job_id}))
@@ -442,7 +462,7 @@ class QuantumInspireAPI:
             result_id: The result identification number.
 
         Raises:
-            ApiError: If the requested result does not exists.
+            ApiError: If the requested result does not exist.
 
         Returns:
             The properties describing the result:
@@ -482,7 +502,26 @@ class QuantumInspireAPI:
         ret: List[Dict[str, Any]] = self._action(['results', 'list'])
         return ret
 
-    def get_raw_data(self, result_id: int) -> List[int]:
+    def get_result_from_job(self, job_id: int) -> Dict[str, Any]:
+        """ Gets the result with its properties for a single job, given the job id.
+
+        Args:
+            job_id: The job identification number.
+
+        Returns:
+            The result with its properties for the job with identification job_id.
+            See `get_result` for a description of the result properties.
+
+        Raises:
+            ApiError: If the job identified by job_id does not exist.
+        """
+        try:
+            result = self._action(['jobs', 'result', 'list'], params={'id': job_id})
+        except ErrorMessage as err_msg:
+            raise ApiError('Job with id {} does not exist!'.format(job_id)) from err_msg
+        return OrderedDict(result)
+
+    def get_raw_data_from_result(self, result_id: int) -> List[int]:
         """ Gets the raw data from the result of the executed cQASM code, given the result_id. The raw data consists
             of a list with integer state values for each shot of the experiment (see job.number_of_shots).
 
@@ -490,15 +529,76 @@ class QuantumInspireAPI:
             result_id: The identification number of the result.
 
         Raises:
-            ApiError: If the requested result with identification result_id does not exists.
+            ApiError: If the requested result with identification result_id does not exist.
 
         Returns:
             The raw data as a list of integer values. An empty list is returned when there is no raw data.
         """
         result = self.get_result(result_id)
         raw_data_url = str(result.get('raw_data_url'))
-        raw_data: List[int] = self.get(raw_data_url)
+        try:
+            token = raw_data_url.split('/')[-2]
+        except IndexError as err_msg:
+            raise ApiError('Invalid raw data url for result with id {}!'.format(result_id)) from err_msg
+        try:
+            raw_data: List[int] = self._action(['results', 'raw-data', 'read'], params={'id': result_id,
+                                                                                        'token': token})
+        except ErrorMessage as err_msg:
+            raise ApiError('Raw data for result with id {} does not exist!'.format(result_id)) from err_msg
         return raw_data
+
+    def get_quantum_states_from_result(self, result_id: int) -> List[Any]:
+        """ Gets the quantum states from the result of the executed cQASM code, given the result_id.
+
+        Args:
+            result_id: The identification number of the result.
+
+        Raises:
+            ApiError: If the requested result with identification result_id does not exist.
+
+        Returns:
+            The quantum states consists of a list of quantum state values. An empty list is returned when there is
+            no data.
+        """
+        result = self.get_result(result_id)
+        quantum_states_url = str(result.get('quantum_states_url'))
+        try:
+            token = quantum_states_url.split('/')[-2]
+        except IndexError as err_msg:
+            raise ApiError('Invalid quantum states url for result with id {}!'.format(result_id)) from err_msg
+        try:
+            quantum_states: List[Any] = self._action(['results', 'quantum-states', 'read'], params={'id': result_id,
+                                                                                                    'token': token})
+        except ErrorMessage as err_msg:
+            raise ApiError('Quantum states for result with id {} does not exist!'.format(result_id)) from err_msg
+        return quantum_states
+
+    def get_measurement_register_from_result(self, result_id: int) -> List[Any]:
+        """ Gets the measurement register from the result of the executed cQASM code, given the result_id.
+
+        Args:
+            result_id: The identification number of the result.
+
+        Raises:
+            ApiError: If the requested result with identification result_id does not exist.
+
+        Returns:
+            The measurement register consists of a list of measurement register values. An empty list is returned
+            when there is no data.
+        """
+        result = self.get_result(result_id)
+        measurement_register_url = str(result.get('measurement_register_url'))
+        try:
+            token = measurement_register_url.split('/')[-2]
+        except IndexError as err_msg:
+            raise ApiError('Invalid measurement register url for result with id {}!'.format(result_id)) from err_msg
+        try:
+            measurement_register: List[Any] = self._action(['results', 'measurement-register', 'read'],
+                                                           params={'id': result_id,
+                                                                   'token': token})
+        except ErrorMessage as err_msg:
+            raise ApiError('Measurement register for result with id {} does not exist!'.format(result_id)) from err_msg
+        return measurement_register
 
     #  assets  #
 
@@ -515,7 +615,7 @@ class QuantumInspireAPI:
             asset_id: The asset identification number.
 
         Raises:
-            ApiError: If the requested asset does not exists.
+            ApiError: If the requested asset does not exist.
 
         Returns:
             The properties describing the asset:
@@ -546,6 +646,51 @@ class QuantumInspireAPI:
         ret: List[Dict[str, Any]] = self._action(['assets', 'list'])
         return ret
 
+    def get_assets_from_project(self, project_id: int) -> List[Dict[str, Any]]:
+        """ Gets the assets with its properties for a single project, given the project id.
+
+        Args:
+            project_id: The project identification number.
+
+        Returns:
+            List of assets with its properties for the project with identification project_id.
+            An empty list is returned when the project has no assets.
+
+        Raises:
+            ApiError: If the project identified by project_id does not exist.
+        """
+        try:
+            assets = self._action(['projects', 'assets', 'list'], params={'id': project_id})
+        except ErrorMessage as err_msg:
+            raise ApiError('Project with id {} does not exist!'.format(project_id)) from err_msg
+        ret: List[Dict[str, Any]] = assets
+        return ret
+
+    def get_asset_from_job(self, job_id: int) -> Dict[str, Any]:
+        """ Gets the asset data from the job, given the job_id.
+
+        Args:
+            job_id: The identification number of the job.
+
+        Raises:
+            ApiError: If the requested asset with identification from the job 'input' field does not exist.
+
+        Returns:
+            The assets with all of its properties.
+            See `get_asset` for a description of the asset properties.
+        """
+        job = self.get_job(job_id)
+        asset_url = str(job.get('input'))
+        try:
+            asset_id = int(asset_url.split('/')[-2])
+        except (ValueError, IndexError) as err_msg:
+            raise ApiError('Invalid input url for job with id {}!'.format(job_id)) from err_msg
+        try:
+            asset = self._action(['assets', 'read'], params={'id': asset_id})
+        except ErrorMessage as err_msg:
+            raise ApiError('Asset with id {} does not exist!'.format(asset_id)) from err_msg
+        return OrderedDict(asset)
+
     def _create_asset(self, name: str, project: Dict[str, Any], content: str) -> Dict[str, Any]:
         """ This method is used by execute_qasm_async to generate a new asset with a unique name to hold the
             content of the cQASM program for the project given. Assets are deleted when the project for which the asset
@@ -570,7 +715,8 @@ class QuantumInspireAPI:
 
     #  other  #
 
-    def _wait_for_completed_job(self, quantum_inspire_job: QuantumInspireJob, collect_max_tries: Optional[int],
+    @staticmethod
+    def _wait_for_completed_job(quantum_inspire_job: QuantumInspireJob, collect_max_tries: Optional[int],
                                 sec_retry_delay: float = 0.5) -> bool:
         """ Holds the process and requests the job status until completed or when
             the maximum number of tries has been reached.

--- a/src/quantuminspire/api.py
+++ b/src/quantuminspire/api.py
@@ -359,7 +359,7 @@ class QuantumInspireAPI:
         return ret
 
     def get_jobs_from_asset(self, asset_id: int) -> List[Dict[str, Any]]:
-        """ Gets the jobs with its properties for a asset, given the asset id.
+        """ Gets the jobs with its properties for an asset, given the asset id.
 
         Args:
             asset_id: The asset identification number.
@@ -529,7 +529,7 @@ class QuantumInspireAPI:
             result_id: The identification number of the result.
 
         Raises:
-            ApiError: If the requested result with identification result_id does not exist.
+            ApiError: If the raw data url in result is invalid or the request for the raw data using the url failed.
 
         Returns:
             The raw data as a list of integer values. An empty list is returned when there is no raw data.
@@ -554,7 +554,8 @@ class QuantumInspireAPI:
             result_id: The identification number of the result.
 
         Raises:
-            ApiError: If the requested result with identification result_id does not exist.
+            ApiError: If the quantum states url in result is invalid or the request for the quantum states using the
+            url failed.
 
         Returns:
             The quantum states consists of a list of quantum state values. An empty list is returned when there is
@@ -580,7 +581,8 @@ class QuantumInspireAPI:
             result_id: The identification number of the result.
 
         Raises:
-            ApiError: If the requested result with identification result_id does not exist.
+            ApiError: If the measurement register url in result is invalid or the request for the measurement register
+            using the url failed.
 
         Returns:
             The measurement register consists of a list of measurement register values. An empty list is returned
@@ -660,11 +662,10 @@ class QuantumInspireAPI:
             ApiError: If the project identified by project_id does not exist.
         """
         try:
-            assets = self._action(['projects', 'assets', 'list'], params={'id': project_id})
+            assets: List[Dict[str, Any]] = self._action(['projects', 'assets', 'list'], params={'id': project_id})
         except ErrorMessage as err_msg:
             raise ApiError('Project with id {} does not exist!'.format(project_id)) from err_msg
-        ret: List[Dict[str, Any]] = assets
-        return ret
+        return assets
 
     def get_asset_from_job(self, job_id: int) -> Dict[str, Any]:
         """ Gets the asset data from the job, given the job_id.

--- a/src/quantuminspire/job.py
+++ b/src/quantuminspire/job.py
@@ -1,5 +1,4 @@
 from typing import Dict, Any
-from collections import OrderedDict
 from coreapi.exceptions import ErrorMessage
 
 
@@ -53,9 +52,8 @@ class QuantumInspireJob:
             histogram of the job. When an error has occurred the raw_text item shall not be
             an empty string.
         """
-        job = self.__api.get_job(self.__job_identifier)
-        result_uri = job['results']
-        return OrderedDict(self.__api.get(result_uri))
+        result: Dict[str, Any] = self.__api.get_result_from_job(self.__job_identifier)
+        return result
 
     def get_job_identifier(self) -> int:
         """ Gets the set job identification number for the wrapped job.
@@ -71,6 +69,5 @@ class QuantumInspireJob:
         Returns:
             The project identification number.
         """
-        job = self.__api.get_job(self.__job_identifier)
-        asset = self.__api.get(job['input'])
+        asset = self.__api.get_asset_from_job(self.__job_identifier)
         return int(asset['project_id'])

--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -180,7 +180,7 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
             A list of experiment results; containing the data, execution time, status, etc.
         """
         jobs = self.__api.get_jobs_from_project(int(qi_job.job_id()))
-        results = [self.__api.get(job['results']) for job in jobs]
+        results = [self.__api.get_result_from_job(job['id']) for job in jobs]
         experiment_results = []
         for result, job in zip(results, jobs):
             if not result.get('histogram', {}):
@@ -365,7 +365,7 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
         memory_data = []
         histogram_data: Dict[str, int] = defaultdict(lambda: 0)
         number_of_qubits: int = result['number_of_qubits']
-        raw_data = self.__api.get_raw_data(result['id'])
+        raw_data = self.__api.get_raw_data_from_result(result['id'])
         if raw_data:
             for raw_qubit_register in raw_data:
                 classical_state_hex = QuantumInspireBackend.__qubit_to_classical_hex(str(raw_qubit_register),

--- a/src/tests/quantuminspire/qiskit/test_backend_qx.py
+++ b/src/tests/quantuminspire/qiskit/test_backend_qx.py
@@ -144,8 +144,8 @@ class TestQiSimulatorPy(unittest.TestCase):
 
     def test_get_experiment_results_RaisesSimulationError_when_no_histogram(self):
         api = Mock()
-        api.get.return_value = {'histogram': [], 'raw_text': 'Error'}
-        api.get_jobs_from_project.return_value = [{'results': '{}'}]
+        api.get_jobs_from_project.return_value = [{'id': 42, 'results': '{}'}]
+        api.get_result_from_job.return_value = {'histogram': [], 'raw_text': 'Error'}
         job = Mock()
         job.job_id.return_value = '42'
         simulator = QuantumInspireBackend(api, Mock())
@@ -161,10 +161,10 @@ class TestQiSimulatorPy(unittest.TestCase):
                         {'name': 'measure', 'qubits': [0], 'memory': [0]}]
         experiment = self._instructions_to_two_qubit_experiment(instructions)
         api = Mock()
-        api.get.return_value = {'id': 1, 'histogram': {'1': 0.6, '3': 0.4}, 'execution_time_in_seconds': 2.1,
-                                'number_of_qubits': 2,
-                                'raw_data_url': 'http://saevar-qutech-nginx/api/results/24/raw-data/'}
-        api.get_raw_data.return_value = [1] * 60 + [3] * 40
+        api.get_result_from_job.return_value = {'id': 1, 'histogram': {'1': 0.6, '3': 0.4},
+                                                'execution_time_in_seconds': 2.1, 'number_of_qubits': 2,
+                                                'raw_data_url': 'http://saevar-qutech-nginx/api/results/24/raw-data/'}
+        api.get_raw_data_from_result.return_value = [1] * 60 + [3] * 40
         jobs = self._basic_job_dictionary
         measurements = QuantumInspireBackend._collect_measurements(experiment)
         user_data = {'name': 'name', 'memory_slots': 2,
@@ -193,10 +193,10 @@ class TestQiSimulatorPy(unittest.TestCase):
                         {'name': 'measure', 'qubits': [0], 'memory': [0]}]
         experiment = self._instructions_to_two_qubit_experiment(instructions)
         api = Mock()
-        api.get.return_value = {'id': 1, 'histogram': {'0': 0.5, '3': 0.5}, 'execution_time_in_seconds': 2.1,
-                                'number_of_qubits': 2,
-                                'raw_data_url': 'http://saevar-qutech-nginx/api/results/24/raw-data/'}
-        api.get_raw_data.return_value = []
+        api.get_result_from_job.return_value = {'id': 1, 'histogram': {'0': 0.5, '3': 0.5},
+                                                'execution_time_in_seconds': 2.1, 'number_of_qubits': 2,
+                                                'raw_data_url': 'http://saevar-qutech-nginx/api/results/24/raw-data/'}
+        api.get_raw_data_from_result.return_value = []
         jobs = self._basic_job_dictionary
         measurements = QuantumInspireBackend._collect_measurements(experiment)
         user_data = {'name': 'name', 'memory_slots': 2,
@@ -232,10 +232,11 @@ class TestQiSimulatorPy(unittest.TestCase):
                             {'name': 'measure', 'qubits': [0], 'memory': [0]}]
             experiment = self._instructions_to_two_qubit_experiment(instructions)
             api = Mock()
-            api.get.return_value = {'id': 1, 'histogram': {'0': 0.2, '1': 0.3, '2': 0.4, '3': 0.1},
-                                    'execution_time_in_seconds': 2.1, 'number_of_qubits': 2,
-                                    'raw_data_url': 'http://saevar-qutech-nginx/api/results/24/raw-data/'}
-            api.get_raw_data.return_value = []
+            api.get_result_from_job.return_value = {'id': 1, 'histogram': {'0': 0.2, '1': 0.3, '2': 0.4, '3': 0.1},
+                                                    'execution_time_in_seconds': 2.1, 'number_of_qubits': 2,
+                                                    'raw_data_url':
+                                                        'http://saevar-qutech-nginx/api/results/24/raw-data/'}
+            api.get_raw_data_from_result.return_value = []
             jobs = self._basic_job_dictionary
             measurements = QuantumInspireBackend._collect_measurements(experiment)
             user_data = {'name': 'name', 'memory_slots': 2,
@@ -325,13 +326,13 @@ class ApiMock(Mock):
         self.result = res1
         self.raw_data = res2
 
-    def get_raw_data(self, result_id):
+    def get_raw_data_from_result(self, result_id):
         if result_id == 1:
             return self.raw_data
         return None
 
-    def get(self, url):
-        if 'result' in url:
+    def get_result_from_job(self, job_id):
+        if job_id == 24:
             return self.result
         return None
 

--- a/src/tests/quantuminspire/test_api.py
+++ b/src/tests/quantuminspire/test_api.py
@@ -675,7 +675,7 @@ class TestQuantumInspireAPI(TestCase):
         self.coreapi_client.handlers['results'] = partial(self.__mock_errors_in_result_handler,
                                                           expected_payload, 'read')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
-        self.assertRaisesRegex(ApiError, 'Invalid raw data url for result with', api.get_raw_data_from_result,
+        self.assertRaisesRegex(ApiError, 'Invalid raw data url for result with id 485!', api.get_raw_data_from_result,
                                result_id=result_identity)
 
     def test_get_raw_data_invalid_from_result_RaisesApiError(self):
@@ -684,8 +684,8 @@ class TestQuantumInspireAPI(TestCase):
         self.coreapi_client.handlers['results'] = partial(self.__mock_errors_in_result_handler,
                                                           expected_payload, 'read')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
-        self.assertRaisesRegex(ApiError, 'Raw data for result with id', api.get_raw_data_from_result,
-                               result_id=result_identity)
+        self.assertRaisesRegex(ApiError, 'Raw data for result with id 486 does not exist!',
+                               api.get_raw_data_from_result, result_id=result_identity)
 
     def test_get_quantum_states_from_result_HasCorrectInputAndOutput(self):
         identity = 485
@@ -703,7 +703,7 @@ class TestQuantumInspireAPI(TestCase):
         self.coreapi_client.handlers['results'] = partial(self.__mock_errors_in_result_handler,
                                                           expected_payload, 'read')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
-        self.assertRaisesRegex(ApiError, 'Invalid quantum states url for result with',
+        self.assertRaisesRegex(ApiError, 'Invalid quantum states url for result with id 485!',
                                api.get_quantum_states_from_result, result_id=result_identity)
 
     def test_get_quantum_states_invalid_from_result_RaisesApiError(self):
@@ -712,7 +712,7 @@ class TestQuantumInspireAPI(TestCase):
         self.coreapi_client.handlers['results'] = partial(self.__mock_errors_in_result_handler,
                                                           expected_payload, 'read')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
-        self.assertRaisesRegex(ApiError, 'Quantum states for result with id',
+        self.assertRaisesRegex(ApiError, 'Quantum states for result with id 486 does not exist!',
                                api.get_quantum_states_from_result, result_id=result_identity)
 
     def test_get_measurement_register_from_result_HasCorrectInputAndOutput(self):
@@ -732,7 +732,7 @@ class TestQuantumInspireAPI(TestCase):
         self.coreapi_client.handlers['results'] = partial(self.__mock_errors_in_result_handler,
                                                           expected_payload, 'read')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
-        self.assertRaisesRegex(ApiError, 'Invalid measurement register url for result with',
+        self.assertRaisesRegex(ApiError, 'Invalid measurement register url for result with id 485!',
                                api.get_measurement_register_from_result, result_id=result_identity)
 
     def test_get_measurement_register_invalid_from_result_RaisesApiError(self):
@@ -741,7 +741,7 @@ class TestQuantumInspireAPI(TestCase):
         self.coreapi_client.handlers['results'] = partial(self.__mock_errors_in_result_handler,
                                                           expected_payload, 'read')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
-        self.assertRaisesRegex(ApiError, 'Measurement register for result with id',
+        self.assertRaisesRegex(ApiError, 'Measurement register for result with id 486 does not exist!',
                                api.get_measurement_register_from_result, result_id=result_identity)
 
     def __mock_list_assets_handler(self, mock_api, document, keys, params=None, validate=None,
@@ -856,7 +856,8 @@ class TestQuantumInspireAPI(TestCase):
         self.coreapi_client.handlers['projects'] = self.__mock_list_assets_handler
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
         other_identity = 999
-        self.assertRaises(ApiError, api.get_assets_from_project, project_id=other_identity)
+        self.assertRaisesRegex(ApiError, 'Project with id 999 does not exist!', api.get_assets_from_project,
+                               project_id=other_identity)
 
     def test_get_assets_from_job_HasCorrectInputAndOutput(self):
         identity = 171
@@ -878,7 +879,8 @@ class TestQuantumInspireAPI(TestCase):
         expected_payload_job = {'id': job_identity}
         self.coreapi_client.handlers['jobs'] = partial(self.__mock_asset_from_job_handler, expected_payload_job, 'read')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
-        self.assertRaisesRegex(ApiError, 'Asset with id', api.get_asset_from_job, job_id=job_identity)
+        self.assertRaisesRegex(ApiError, 'Asset with id 999 does not exist!', api.get_asset_from_job,
+                               job_id=job_identity)
 
     def test_get_asset_invalid_from_job_RaisesApiError(self):
         identity = 999
@@ -888,7 +890,8 @@ class TestQuantumInspireAPI(TestCase):
         expected_payload_job = {'id': job_identity}
         self.coreapi_client.handlers['jobs'] = partial(self.__mock_asset_from_job_handler, expected_payload_job, 'read')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
-        self.assertRaisesRegex(ApiError, 'Invalid input url', api.get_asset_from_job, job_id=job_identity)
+        self.assertRaisesRegex(ApiError, 'Invalid input url for job with id 510!', api.get_asset_from_job,
+                               job_id=job_identity)
 
     def test_create_asset_HasCorrectInputAndOutput(self):
         name = 'TestAsset'
@@ -912,7 +915,6 @@ class TestQuantumInspireAPI(TestCase):
         expected_payload = {'id': job_id}
         self.coreapi_client.handlers['jobs'] = partial(self.__mock_job_handler, expected_payload, 'read',
                                                        status='COMPLETE')
-
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
         quantum_inspire_job = QuantumInspireJob(api, job_id)
         is_completed = api._wait_for_completed_job(quantum_inspire_job, collect_max_tries, sec_retry_delay=0.0)

--- a/src/tests/quantuminspire/test_api.py
+++ b/src/tests/quantuminspire/test_api.py
@@ -69,7 +69,7 @@ class TestQuantumInspireAPI(TestCase):
         expected = 'Test'
         self.coreapi_client.getters[mock_key] = expected
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
-        actual = api.get(mock_key)
+        actual = api._get(mock_key)
         self.assertEqual(expected, actual)
 
     def test_action_HasCorrectOutput(self, mock_key='MockKey', mock_result=1234):
@@ -285,8 +285,7 @@ class TestQuantumInspireAPI(TestCase):
         expected_payload = {'id': identity}
         self.coreapi_client.handlers['projects'] = partial(self.__mock_project_handler, expected_payload, 'delete')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
-        actual = api.delete_project(project_id=identity)
-        self.assertIsNone(actual)
+        self.assertIsNone(api.delete_project(project_id=identity))
 
     def test_delete_project_RaisesApiError(self):
         identity = 999
@@ -332,13 +331,42 @@ class TestQuantumInspireAPI(TestCase):
                             ('name', 'qi-sdk-job-7e37c8fa-a76b-11e8-b5a0-a44cc848f1f2'),
                             ('id', 509),
                             ('status', status),
-                            ('input', 'https,//api.quantum-inspire.com/assets/607/'),
+                            ('input', 'https,//api.quantum-inspire.com/assets/171/'),
                             ('backend', 'https,//api.quantum-inspire.com/backends/1/'),
                             ('backend_type', 'https,//api.quantum-inspire.com/backendtypes/1/'),
                             ('results', 'https,//api.quantum-inspire.com/jobs/509/result/'),
                             ('queued_at', '2018-08-24T07:01:21:257557Z'),
                             ('number_of_shots', 1024),
                             ('user_data', '')])
+
+    def __mock_assets_jobs_handler(self, input_params, input_key, mock_api, document, keys, params=None,
+                                   validate=None, overrides=None, action=None, encoding=None, transform=None):
+        self.assertDictEqual(params, input_params)
+        self.assertEqual(keys[1], input_key)
+        if input_key == 'read' or input_key == 'delete' or input_key == 'jobs':
+            if params['id'] != 171:
+                raise ErrorMessage('Not found')
+        return [OrderedDict([('url', 'https,//api.quantum-inspire.com/jobs/530/'),
+                             ('name', 'qi-sdk-job-5852eb68-a794-11e8-9447-a44cc848f1f2'),
+                             ('id', 530),
+                             ('status', 'COMPLETE'),
+                             ('input', 'https,//api.quantum-inspire.com/assets/629/'),
+                             ('backend', 'https,//api.quantum-inspire.com/backends/1/'),
+                             ('backend_type', 'https,//api.quantum-inspire.com/backendtypes/1/'),
+                             ('results', 'https,//api.quantum-inspire.com/jobs/530/result/'),
+                             ('queued_at', '2018-08-24T11:53:41:352732Z'),
+                             ('number_of_shots', 1024)]),
+                OrderedDict([('url', 'https,//api.quantum-inspire.com/jobs/509/'),
+                             ('name', 'qi-sdk-job-7e37c8fa-a76b-11e8-b5a0-a44cc848f1f2'),
+                             ('id', 509),
+                             ('status', 'COMPLETE'),
+                             ('input', 'https,//api.quantum-inspire.com/assets/607/'),
+                             ('backend', 'https,//api.quantum-inspire.com/backends/1/'),
+                             ('backend_type', 'https,//api.quantum-inspire.com/backendtypes/1/'),
+                             ('results', 'https,//api.quantum-inspire.com/jobs/509/result/'),
+                             ('queued_at', '2018-08-24T07:01:21:257557Z'),
+                             ('number_of_shots', 1024),
+                             ('user_data', '')])]
 
     def test_list_jobs_HasCorrectInputAndOutput(self):
         self.coreapi_client.handlers['jobs'] = self.__mock_list_jobs_handler
@@ -384,6 +412,23 @@ class TestQuantumInspireAPI(TestCase):
         self.coreapi_client.handlers['projects'] = partial(self.__mock_job_handler, expected_payload, 'jobs')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
         self.assertRaises(ApiError, api.get_jobs_from_project, project_id=identity)
+
+    def test_get_jobs_from_asset_HasCorrectInAndOutput(self):
+        identity = 171
+        expected_payload = {'id': identity}
+        expected = self.__mock_assets_jobs_handler(expected_payload, 'jobs', None, None, ['assets', 'jobs'],
+                                                   expected_payload)
+        self.coreapi_client.handlers['assets'] = partial(self.__mock_assets_jobs_handler, expected_payload, 'jobs')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        actual = api.get_jobs_from_asset(asset_id=identity)
+        self.assertListEqual(actual, expected)
+
+    def test_get_jobs_from_asset_RaisesApiError(self):
+        identity = 999
+        expected_payload = {'id': identity}
+        self.coreapi_client.handlers['assets'] = partial(self.__mock_assets_jobs_handler, expected_payload, 'jobs')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        self.assertRaises(ApiError, api.get_jobs_from_asset, asset_id=identity)
 
     def test_delete_job_HasCorrectInAndOutput(self):
         identity = 509
@@ -441,7 +486,8 @@ class TestQuantumInspireAPI(TestCase):
                              ('histogram', {'3', 0.5068359375, '0', 0.4931640625}),
                              ('histogram_url', 'https,//api.quantum-inspire.com/results/502/histogram/f2b6/'),
                              ('measurement_mask', 0),
-                             ('quantum_states_url', 'https,//api.quantum-inspire.com/results/502/quantum-states/f2b6d/'),
+                             ('quantum_states_url',
+                              'https,//api.quantum-inspire.com/results/502/quantum-states/f2b6d/'),
                              ('measurement_register_url', 'https,//api.quantum-inspire.com/results/502/f2b6d/')]),
                 OrderedDict([('id', 485),
                              ('url', 'https,//api.quantum-inspire.com/results/485/'),
@@ -459,10 +505,46 @@ class TestQuantumInspireAPI(TestCase):
 
     def __mock_result_handler(self, input_params, input_key, mock_api, document, keys, params=None,
                               validate=None, overrides=None, action=None, encoding=None, transform=None):
-        self.assertDictEqual(params, input_params)
-        self.assertEqual(keys[1], input_key)
+        self.assertEqual(params['id'], input_params['id'])
+        self.assertTrue(keys[1] == input_key or keys[2] == input_key)
         if input_key == 'read':
             if params['id'] != 485:
+                raise ErrorMessage('Not found')
+        if keys[1] == 'read':
+            return OrderedDict([('id', 485),
+                                ('url', 'https,//api.quantum-inspire.com/results/485/'),
+                                ('job', 'https,//api.quantum-inspire.com/jobs/20/'),
+                                ('created_at', '1900-01-01T01:00:00:00000Z'),
+                                ('number_of_qubits', 2),
+                                ('seconds', 0.0),
+                                ('raw_text', ''),
+                                ('raw_data_url', 'https,//api.quantum-inspire.com/results/485/raw-data/162c/'),
+                                ('histogram', {'0', 0.5029296875, '3', 0.4970703125}),
+                                ('histogram_url', 'https,//api.quantum-inspire.com/results/485/histogram/162c/'),
+                                ('measurement_mask', 0),
+                                ('quantum_states_url',
+                                 'https,//api.quantum-inspire.com/results/485/quantum-states/qstates/'),
+                                ('measurement_register_url', 'https,//api.quantum-inspire.com/results/485/mreg/')])
+        elif keys[1] == 'raw-data':
+            if params['token'] != '162c':
+                raise ErrorMessage('Not found')
+            return [0, 3, 3, 0]
+        elif keys[1] == 'quantum-states':
+            if params['token'] != 'qstates':
+                raise ErrorMessage('Not found')
+            return [1, 2, 3, 4]
+        else:
+            self.assertTrue(keys[1] == 'measurement-register')
+            if params['token'] != 'mreg':
+                raise ErrorMessage('Not found')
+            return [4, 3, 2, 1]
+
+    def __mock_list_result_from_job_handler(self, input_params, input_key, mock_api, document, keys, params=None,
+                                            validate=None, overrides=None, action=None, encoding=None, transform=None):
+        self.assertEqual(params['id'], input_params['id'])
+        self.assertTrue(keys[2] == input_key)
+        if input_key == 'list':
+            if params['id'] != 509:
                 raise ErrorMessage('Not found')
         return OrderedDict([('id', 485),
                             ('url', 'https,//api.quantum-inspire.com/results/485/'),
@@ -478,9 +560,54 @@ class TestQuantumInspireAPI(TestCase):
                             ('quantum_states_url', 'https,//api.quantum-inspire.com/results/485/quantum-states/162c/'),
                             ('measurement_register_url', 'https,//api.quantum-inspire.com/results/485/162c/')])
 
-    def __mock_raw_data_handler(self, input_url):
-        self.assertTrue('raw-data' in input_url)
-        return [0, 3, 3, 0]
+    def __mock_errors_in_result_handler(self, input_params, input_key, mock_api, document, keys, params=None,
+                                        validate=None, overrides=None, action=None, encoding=None, transform=None):
+        self.assertEqual(params['id'], input_params['id'])
+        self.assertTrue(keys[1] == input_key or keys[2] == input_key)
+        if keys[1] == 'read':
+            if params['id'] == 485:
+                return OrderedDict([('id', 485),
+                                    ('url', 'https,//api.quantum-inspire.com/results/485/'),
+                                    ('job', 'https,//api.quantum-inspire.com/jobs/20/'),
+                                    ('created_at', '1900-01-01T01:00:00:00000Z'),
+                                    ('number_of_qubits', 2),
+                                    ('seconds', 0.0),
+                                    ('raw_text', ''),
+                                    ('raw_data_url', ''),
+                                    ('histogram', {'0', 0.5029296875, '3', 0.4970703125}),
+                                    ('histogram_url', 'https,//api.quantum-inspire.com/results/485/histogram/162c/'),
+                                    ('measurement_mask', 0),
+                                    ('quantum_states_url', ''),
+                                    ('measurement_register_url', '')])
+            else:
+                self.assertEqual(params['id'], 486)
+                return OrderedDict([('id', 486),
+                                    ('url', 'https,//api.quantum-inspire.com/results/485/'),
+                                    ('job', 'https,//api.quantum-inspire.com/jobs/20/'),
+                                    ('created_at', '1900-01-01T01:00:00:00000Z'),
+                                    ('number_of_qubits', 2),
+                                    ('seconds', 0.0),
+                                    ('raw_text', ''),
+                                    ('raw_data_url', 'https,//api.quantum-inspire.com/results/485/raw-data/999/'),
+                                    ('histogram', {'0', 0.5029296875, '3', 0.4970703125}),
+                                    ('histogram_url', 'https,//api.quantum-inspire.com/results/485/histogram/162c/'),
+                                    ('measurement_mask', 0),
+                                    ('quantum_states_url',
+                                     'https,//api.quantum-inspire.com/results/485/quantum-states/999/'),
+                                    ('measurement_register_url', 'https,//api.quantum-inspire.com/results/485/999/')])
+        elif keys[1] == 'raw-data':
+            if params['token'] != '162c':
+                raise ErrorMessage('Not found')
+            return [0, 3, 3, 0]
+        elif keys[1] == 'quantum-states':
+            if params['token'] != 'qstates':
+                raise ErrorMessage('Not found')
+            return [1, 2, 3, 4]
+        else:
+            self.assertTrue(keys[1] == 'measurement-register')
+            if params['token'] != 'mreg':
+                raise ErrorMessage('Not found')
+            return [4, 3, 2, 1]
 
     def test_list_results_HasCorrectOutput(self):
         self.coreapi_client.handlers['results'] = self.__mock_list_results_handler
@@ -513,20 +640,116 @@ class TestQuantumInspireAPI(TestCase):
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
         self.assertRaises(ApiError, api.get_result, result_id=identity)
 
-    def test_get_raw_data_HasCorrectInputAndOutput(self):
-        identity = 485
+    def test_get_result_from_job_HasCorrectInputAndOutput(self):
+        identity = 509
         expected_payload = {'id': identity}
-        expected_raw_data = self.__mock_raw_data_handler('https,//api.quantum-inspire.com/results/485/raw-data/162c/')
-        self.coreapi_client.handlers['results'] = partial(self.__mock_result_handler, expected_payload, 'read')
-        self.coreapi_client.getters['https,//api.quantum-inspire.com/results/485/raw-data/162c/'] = \
-            self.__mock_raw_data_handler('https,//api.quantum-inspire.com/results/485/raw-data/162c/')
+        expected = self.__mock_list_result_from_job_handler(expected_payload, 'list', None, None,
+                                                            ['jobs', 'result', 'list'], expected_payload)
+        self.coreapi_client.handlers['jobs'] = partial(self.__mock_list_result_from_job_handler, expected_payload,
+                                                       'list')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
-        actual = api.get_raw_data(result_id=identity)
+        actual = api.get_result_from_job(identity)
+        self.assertDictEqual(actual, expected)
+
+    def test_get_result_from_job_RaisesApiError(self):
+        identity = 999
+        expected_payload = {'id': identity}
+        self.coreapi_client.handlers['jobs'] = partial(self.__mock_list_result_from_job_handler, expected_payload,
+                                                       'list')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        self.assertRaises(ApiError, api.get_result_from_job, job_id=identity)
+
+    def test_get_raw_data_from_result_HasCorrectInputAndOutput(self):
+        identity = 485
+        expected_payload = {'id': identity, 'token': '162c'}
+        expected_raw_data = self.__mock_result_handler(expected_payload, 'read', None, None,
+                                                       ['test', 'raw-data', 'read'], expected_payload)
+        self.coreapi_client.handlers['results'] = partial(self.__mock_result_handler, expected_payload, 'read')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        actual = api.get_raw_data_from_result(result_id=identity)
         self.assertListEqual(actual, expected_raw_data)
+
+    def test_get_raw_data_unknown_from_result_RaisesApiError(self):
+        result_identity = 485
+        expected_payload = {'id': result_identity}
+        self.coreapi_client.handlers['results'] = partial(self.__mock_errors_in_result_handler,
+                                                          expected_payload, 'read')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        self.assertRaisesRegex(ApiError, 'Invalid raw data url for result with', api.get_raw_data_from_result,
+                               result_id=result_identity)
+
+    def test_get_raw_data_invalid_from_result_RaisesApiError(self):
+        result_identity = 486
+        expected_payload = {'id': result_identity, 'token': '162c'}
+        self.coreapi_client.handlers['results'] = partial(self.__mock_errors_in_result_handler,
+                                                          expected_payload, 'read')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        self.assertRaisesRegex(ApiError, 'Raw data for result with id', api.get_raw_data_from_result,
+                               result_id=result_identity)
+
+    def test_get_quantum_states_from_result_HasCorrectInputAndOutput(self):
+        identity = 485
+        expected_payload = {'id': identity, 'token': 'qstates'}
+        expected_quantum_states = self.__mock_result_handler(expected_payload, 'read', None, None,
+                                                             ['test', 'quantum-states', 'read'], expected_payload)
+        self.coreapi_client.handlers['results'] = partial(self.__mock_result_handler, expected_payload, 'read')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        actual = api.get_quantum_states_from_result(result_id=identity)
+        self.assertListEqual(actual, expected_quantum_states)
+
+    def test_get_quantum_states_unknown_from_result_RaisesApiError(self):
+        result_identity = 485
+        expected_payload = {'id': result_identity, 'token': 'qstates'}
+        self.coreapi_client.handlers['results'] = partial(self.__mock_errors_in_result_handler,
+                                                          expected_payload, 'read')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        self.assertRaisesRegex(ApiError, 'Invalid quantum states url for result with',
+                               api.get_quantum_states_from_result, result_id=result_identity)
+
+    def test_get_quantum_states_invalid_from_result_RaisesApiError(self):
+        result_identity = 486
+        expected_payload = {'id': result_identity, 'token': 'qstates'}
+        self.coreapi_client.handlers['results'] = partial(self.__mock_errors_in_result_handler,
+                                                          expected_payload, 'read')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        self.assertRaisesRegex(ApiError, 'Quantum states for result with id',
+                               api.get_quantum_states_from_result, result_id=result_identity)
+
+    def test_get_measurement_register_from_result_HasCorrectInputAndOutput(self):
+        identity = 485
+        expected_payload = {'id': identity, 'token': 'mreg'}
+        expected_measurement_register = self.__mock_result_handler(expected_payload, 'read', None, None,
+                                                                   ['test', 'measurement-register', 'read'],
+                                                                   expected_payload)
+        self.coreapi_client.handlers['results'] = partial(self.__mock_result_handler, expected_payload, 'read')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        actual = api.get_measurement_register_from_result(result_id=identity)
+        self.assertListEqual(actual, expected_measurement_register)
+
+    def test_get_measurement_register_unknown_from_result_RaisesApiError(self):
+        result_identity = 485
+        expected_payload = {'id': result_identity, 'token': 'qstates'}
+        self.coreapi_client.handlers['results'] = partial(self.__mock_errors_in_result_handler,
+                                                          expected_payload, 'read')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        self.assertRaisesRegex(ApiError, 'Invalid measurement register url for result with',
+                               api.get_measurement_register_from_result, result_id=result_identity)
+
+    def test_get_measurement_register_invalid_from_result_RaisesApiError(self):
+        result_identity = 486
+        expected_payload = {'id': result_identity, 'token': 'qstates'}
+        self.coreapi_client.handlers['results'] = partial(self.__mock_errors_in_result_handler,
+                                                          expected_payload, 'read')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        self.assertRaisesRegex(ApiError, 'Measurement register for result with id',
+                               api.get_measurement_register_from_result, result_id=result_identity)
 
     def __mock_list_assets_handler(self, mock_api, document, keys, params=None, validate=None,
                                    overrides=None, action=None, encoding=None, transform=None):
-        self.assertEqual(keys[1], 'list')
+        self.assertTrue(keys[1] == 'list' or keys[2] == 'list')
+        if keys[0] == 'projects':
+            if params['id'] != 11:
+                raise ErrorMessage('Not found')
         return [OrderedDict([('url', 'https,//api.quantum-inspire.com/assets/31/'),
                              ('id', 31),
                              ('name', 'Grover algorithm - 2018-07-18 13,32'),
@@ -557,6 +780,36 @@ class TestQuantumInspireAPI(TestCase):
                             ('project', 'https,//api.quantum-inspire.com/projects/11/'),
                             ('project_id', 11)])
 
+    def __mock_asset_from_job_handler(self, input_params, input_key, mock_api, document, keys, params=None,
+                                      validate=None, overrides=None, action=None, encoding=None, transform=None,
+                                      status='COMPLETE'):
+        self.assertDictEqual(params, input_params)
+        self.assertEqual(keys[1], input_key)
+        if params['id'] == 509:
+            return OrderedDict([('url', 'https,//api.quantum-inspire.com/jobs/509/'),
+                                ('name', 'qi-sdk-job-7e37c8fa-a76b-11e8-b5a0-a44cc848f1f2'),
+                                ('id', 509),
+                                ('status', status),
+                                ('input', 'https,//api.quantum-inspire.com/assets/999/'),
+                                ('backend', 'https,//api.quantum-inspire.com/backends/1/'),
+                                ('backend_type', 'https,//api.quantum-inspire.com/backendtypes/1/'),
+                                ('results', 'https,//api.quantum-inspire.com/jobs/509/result/'),
+                                ('queued_at', '2018-08-24T07:01:21:257557Z'),
+                                ('number_of_shots', 1024),
+                                ('user_data', '')])
+        elif params['id'] == 510:
+            return OrderedDict([('url', 'https,//api.quantum-inspire.com/jobs/509/'),
+                                ('name', 'qi-sdk-job-7e37c8fa-a76b-11e8-b5a0-a44cc848f1f2'),
+                                ('id', 510),
+                                ('status', status),
+                                ('input', 'https,//api.quantum-inspire.com/assets/negennegennegen/'),
+                                ('backend', 'https,//api.quantum-inspire.com/backends/1/'),
+                                ('backend_type', 'https,//api.quantum-inspire.com/backendtypes/1/'),
+                                ('results', 'https,//api.quantum-inspire.com/jobs/509/result/'),
+                                ('queued_at', '2018-08-24T07:01:21:257557Z'),
+                                ('number_of_shots', 1024),
+                                ('user_data', '')])
+
     def test_list_assets_HasCorrectOutput(self):
         self.coreapi_client.handlers['assets'] = self.__mock_list_assets_handler
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
@@ -581,12 +834,61 @@ class TestQuantumInspireAPI(TestCase):
         actual = api.get_asset(asset_id=identity)
         self.assertDictEqual(actual, expected)
 
-    def test_get_asset_from_project_RaisesApiError(self):
+    def test_get_asset_RaisesApiError(self):
         identity = 999
         expected_payload = {'id': identity}
         self.coreapi_client.handlers['assets'] = partial(self.__mock_asset_handler, expected_payload, 'read')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
         self.assertRaises(ApiError, api.get_asset, asset_id=identity)
+
+    def test_get_assets_from_project_HasCorrectInputAndOutput(self):
+        identity = 11
+        expected_payload = {'id': identity}
+        expected = self.__mock_list_assets_handler(None, None, ['projects', 'assets', 'list'], expected_payload)
+        self.coreapi_client.handlers['projects'] = self.__mock_list_assets_handler
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        actual = api.get_assets_from_project(identity)
+        self.assertListEqual(actual, expected)
+
+    def test_get_assets_from_project_RaisesApiError(self):
+        identity = 11
+        expected_payload = {'id': identity}
+        self.coreapi_client.handlers['projects'] = self.__mock_list_assets_handler
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        other_identity = 999
+        self.assertRaises(ApiError, api.get_assets_from_project, project_id=other_identity)
+
+    def test_get_assets_from_job_HasCorrectInputAndOutput(self):
+        identity = 171
+        expected_payload = {'id': identity}
+        expected = self.__mock_asset_handler(expected_payload, 'read', None, None, ['assets', 'read'], expected_payload)
+        self.coreapi_client.handlers['assets'] = partial(self.__mock_asset_handler, expected_payload, 'read')
+        job_identity = 509
+        expected_payload_job = {'id': job_identity}
+        self.coreapi_client.handlers['jobs'] = partial(self.__mock_job_handler, expected_payload_job, 'read')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        actual = api.get_asset_from_job(job_identity)
+        self.assertDictEqual(actual, expected)
+
+    def test_get_asset_unknown_from_job_RaisesApiError(self):
+        identity = 999
+        expected_payload = {'id': identity}
+        self.coreapi_client.handlers['assets'] = partial(self.__mock_asset_handler, expected_payload, 'read')
+        job_identity = 509
+        expected_payload_job = {'id': job_identity}
+        self.coreapi_client.handlers['jobs'] = partial(self.__mock_asset_from_job_handler, expected_payload_job, 'read')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        self.assertRaisesRegex(ApiError, 'Asset with id', api.get_asset_from_job, job_id=job_identity)
+
+    def test_get_asset_invalid_from_job_RaisesApiError(self):
+        identity = 999
+        expected_payload = {'id': identity}
+        self.coreapi_client.handlers['assets'] = partial(self.__mock_asset_handler, expected_payload, 'read')
+        job_identity = 510
+        expected_payload_job = {'id': job_identity}
+        self.coreapi_client.handlers['jobs'] = partial(self.__mock_asset_from_job_handler, expected_payload_job, 'read')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        self.assertRaisesRegex(ApiError, 'Invalid input url', api.get_asset_from_job, job_id=job_identity)
 
     def test_create_asset_HasCorrectInputAndOutput(self):
         name = 'TestAsset'
@@ -692,12 +994,12 @@ class TestQuantumInspireAPI(TestCase):
                              overrides=None, action=None, encoding=None, transform=None, call_mock=None):
         if call_mock:
             call_mock(keys[1])
-        return OrderedDict([('url', 'https,//api.quantum-inspire.com/assets/1/'),
+        return OrderedDict([('url', 'https//api.quantum-inspire.com/assets/1/'),
                             ('id', 171),
                             ('name', 'Grover algorithm - 2018-07-18 13,32'),
                             ('contentType', 'text/plain'),
                             ('content', 'version 1.0\n\nqubits 9\n\n\n# Grover search algorithm\n  display'),
-                            ('project', 'https,//api.quantum-inspire.com/projects/1/'),
+                            ('project', 'https//api.quantum-inspire.com/projects/1/'),
                             ('project_id', 1),
                             ('input', {'project_id': 1})])
 
@@ -705,14 +1007,14 @@ class TestQuantumInspireAPI(TestCase):
                            overrides=None, action=None, encoding=None, transform=None, call_mock=None):
         if call_mock:
             call_mock(keys[1], params)
-        return OrderedDict([('url', 'https,//api.quantum-inspire.com/jobs/509/'),
+        return OrderedDict([('url', 'https//api.quantum-inspire.com/jobs/509/'),
                             ('name', 'qi-sdk-job-7e37c8fa-a76b-11e8-b5a0-a44cc848f1f2'),
                             ('id', 509),
                             ('status', 'COMPLETE'),
                             ('full_state_projection', True),
-                            ('input', 'mocked_asset'),
-                            ('backend', 'https,//api.quantum-inspire.com/backends/1/'),
-                            ('backend_type', 'https,//api.quantum-inspire.com/backendtypes/1/'),
+                            ('input', 'https//api.quantum-inspire.com/assets/171/'),
+                            ('backend', 'https//api.quantum-inspire.com/backends/1/'),
+                            ('backend_type', 'https//api.quantum-inspire.com/backendtypes/1/'),
                             ('results', 'mocked_job'),
                             ('queued_at', '2018-08-24T07:01:21:257557Z'),
                             ('number_of_shots', 1)])
@@ -721,13 +1023,13 @@ class TestQuantumInspireAPI(TestCase):
                                       overrides=None, action=None, encoding=None, transform=None, call_mock=None):
         if call_mock:
             call_mock(keys[1])
-        return OrderedDict([('url', 'https,//api.quantum-inspire.com/jobs/509/'),
+        return OrderedDict([('url', 'https//api.quantum-inspire.com/jobs/509/'),
                             ('name', 'qi-sdk-job-7e37c8fa-a76b-11e8-b5a0-a44cc848f1f2'),
                             ('id', 509),
                             ('status', 'FAILED'),
-                            ('input', 'https,//api.quantum-inspire.com/assets/607/'),
-                            ('backend', 'https,//api.quantum-inspire.com/backends/1/'),
-                            ('backend_type', 'https,//api.quantum-inspire.com/backendtypes/1/'),
+                            ('input', 'https//api.quantum-inspire.com/assets/607/'),
+                            ('backend', 'https//api.quantum-inspire.com/backends/1/'),
+                            ('backend_type', 'https//api.quantum-inspire.com/backendtypes/1/'),
                             ('results', ''),
                             ('queued_at', '2018-08-24T07:01:21:257557Z'),
                             ('number_of_shots', 1)])
@@ -736,7 +1038,7 @@ class TestQuantumInspireAPI(TestCase):
         expected_job_result = self.__fake_job_handler({}, 'read', None, None, ['test', 'read'], {})
         self.coreapi_client.getters['mocked_job'] = expected_job_result
         expected_asset = self.__fake_asset_handler({}, 'create', None, None, ['test', 'create'], {})
-        self.coreapi_client.getters['mocked_asset'] = expected_asset
+        self.coreapi_client.getters['171'] = expected_asset
 
         job_mock = Mock()
         self.coreapi_client.handlers['jobs'] = partial(self.__fake_job_handler, call_mock=job_mock)
@@ -813,7 +1115,7 @@ class TestQuantumInspireAPI(TestCase):
         self.assertEqual(256, job_call_items['number_of_shots'])
         self.assertTrue(job_call_items['full_state_projection'])
 
-        asset_mock.assert_called_with('create')
+        asset_mock.assert_any_call('create')
         backend_mock.assert_called_with('default')
         project_mock.assert_has_calls([call('create', params=mock.ANY), call('delete', params={'id': 1})])
 
@@ -831,7 +1133,8 @@ class TestQuantumInspireAPI(TestCase):
         actual_job_result = api.execute_qasm(qasm, number_of_shots=1024, collect_tries=1)
         self.assertEqual(expected_job_result, actual_job_result)
 
-        job_mock.assert_called_with('read', {'id': 509})
+        job_mock.assert_any_call('read', {'id': 509})
+        job_mock.assert_any_call('result', {'id': 509})
         job_call_items = job_mock.call_args_list[0][0][1]
         self.assertEqual('NEW', job_call_items['status'])
         self.assertEqual(1024, job_call_items['number_of_shots'])

--- a/src/tests/quantuminspire/test_job.py
+++ b/src/tests/quantuminspire/test_job.py
@@ -46,17 +46,14 @@ class TestQuantumInspireJob(TestCase):
                                 ('quantum_states_url',
                                  'https,//api.quantum-inspire.com/results/502/quantum-states/f2b6d/'),
                                 ('measurement_register_url', 'https,//api.quantum-inspire.com/results/502/f2b6d/')])
-        result_mock = Mock()
         api = Mock()
-        api.get_job.return_value = {'results': result_mock}
-        api.get.return_value = expected
+        api.get_result_from_job.return_value = expected
         type(api).__name__ = 'QuantumInspireAPI'
         job_identifier = 1
         qi_job = QuantumInspireJob(api, job_identifier)
         actual = qi_job.retrieve_results()
         self.assertDictEqual(expected, actual)
-        api.get_job.assert_called_with(job_identifier)
-        api.get.assert_called_once_with(result_mock)
+        api.get_result_from_job.assert_called_once_with(job_identifier)
 
     def test_get_job_identifier(self):
         api = Mock()
@@ -72,11 +69,11 @@ class TestQuantumInspireJob(TestCase):
         asset = {'project_id': expected}
         type(api).__name__ = 'QuantumInspireAPI'
         api.get_job.return_value = {'input': asset}
-        api.get.return_value = asset
+        api.get_asset_from_job.return_value = asset
 
         job_identifier = 1
         qi_job = QuantumInspireJob(api, job_identifier)
         actual = qi_job.get_project_identifier()
         self.assertEqual(expected, actual)
-        api.get.assert_called_once_with(asset)
+        api.get_asset_from_job.assert_called_once_with(job_identifier)
         api.get_job.assert_called_with(job_identifier)


### PR DESCRIPTION
* Api.get was 'misused' for getting information from the backed. Now it is used once for getting the schema only.
* Api._get is now private method of Api
* Added public methods to Api to get the available information from the backend
* Restructured the unit tests for the code and functions where api.get was used and now another api-method is used.
* Added unit tests for the Api methods I added to get data from the backend now the get method is private.