### PR TITLE
[DEM-537] No manual mapper needed

### DIFF
--- a/docs/example_projectq.ipynb
+++ b/docs/example_projectq.ipynb
@@ -29,7 +29,6 @@
     "\n",
     "from projectq import MainEngine\n",
     "from projectq.setups import linear\n",
-    "from projectq.cengines import ManualMapper\n",
     "from projectq.ops import H, Rx, Rz, CNOT, CZ, Measure, All\n",
     "\n",
     "from quantuminspire.api import QuantumInspireAPI\n",
@@ -91,8 +90,7 @@
     }
    ],
    "source": [
-    "engine_list = [ManualMapper(lambda ii: ii)]\n",
-    "engine = MainEngine(backend=projectq_backend, engine_list=engine_list)  # create default compiler (simulator back-end)\n",
+    "engine = MainEngine(backend=projectq_backend)  # create default compiler (simulator back-end)\n",
     "\n",
     "qubits = engine.allocate_qureg(5)\n",
     "q1 = qubits[0]\n",

--- a/docs/example_projectq_entangle.py
+++ b/docs/example_projectq_entangle.py
@@ -8,7 +8,6 @@ from getpass import getpass
 from coreapi.auth import BasicAuthentication
 from projectq import MainEngine
 from projectq.backends import ResourceCounter
-from projectq.cengines import ManualMapper
 from projectq.ops import CNOT, H, Measure, All
 from projectq.setups import restrictedgateset
 
@@ -34,7 +33,7 @@ if __name__ == '__main__':
     qi_api = QuantumInspireAPI(uri, authentication, project_name=name)
 
     compiler_engines = restrictedgateset.get_engine_list(one_qubit_gates="any", two_qubit_gates=(CNOT,))
-    compiler_engines.extend([ResourceCounter(), ManualMapper(lambda x: x)])
+    compiler_engines.extend([ResourceCounter()])
 
     qi_backend = QIBackend(quantum_inspire_api=qi_api)
     engine = MainEngine(backend=qi_backend, engine_list=compiler_engines)

--- a/docs/example_projectq_grover.py
+++ b/docs/example_projectq_grover.py
@@ -8,7 +8,6 @@ from getpass import getpass
 from coreapi.auth import BasicAuthentication
 from projectq import MainEngine
 from projectq.backends import ResourceCounter, Simulator
-from projectq.cengines import ManualMapper
 from projectq.meta import Compute, Control, Loop, Uncompute
 from projectq.ops import CNOT, CZ, All, H, Measure, Toffoli, X, Z
 from projectq.setups import restrictedgateset
@@ -103,7 +102,7 @@ if __name__ == '__main__':
     qi = QuantumInspireAPI(r'https://api.quantum-inspire.com/', authentication)
 
     compiler_engines = restrictedgateset.get_engine_list(one_qubit_gates="any", two_qubit_gates=(CNOT, CZ, Toffoli))
-    compiler_engines.extend([ResourceCounter(), ManualMapper(lambda x: x)])
+    compiler_engines.extend([ResourceCounter()])
     qi_backend = QIBackend(quantum_inspire_api=qi)
     qi_engine = MainEngine(backend=qi_backend, engine_list=compiler_engines)
 


### PR DESCRIPTION
It was obligatory (by our backend) to define a mapper for using projectq with the SDK. Therefore in our examples a manual mapper is added as an engine to use our backend. In essence this manual mapper mapped logical bit with number n to physical bit with number n.
Any other type of mapper can be used (linear mapper etc). The main engine of projectq doesn't make it obligatory to install a mapper. When no mapper is installed there will be no mapping of physical to logical qubits. In our backend this is now also the default behaviour, when no mapper is added the logical bitnumber becomes the physical bitnumber. This is the same behaviour as the manual mapper used earlier. Earlier when no mapper was detected our backend generated an exception.

Some unit tests are added, to test the default behaviour of our backend when no mapper is added to the main engine.

Furthermore the exception text in the "statement after flush" exception is changed to be more descriptive what is really happening.

