### PR TITLE
[DEM-757] token reprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ if you intend to write a new backend for an existing SDK.
 A simple example to perform entanglement between two qubits by using the
 API wrapper directly:
 
-``` python
+```python
 from getpass import getpass
 from coreapi.auth import BasicAuthentication
 from quantuminspire.api import QuantumInspireAPI
@@ -121,7 +121,43 @@ result = qi.execute_qasm(qasm, backend_type=backend_type, number_of_shots=1024)
 print(result['histogram'])
 ```
 
-## Known issues
+## Configure your token credentials for Quantum Inspire (expected soon)
+
+1. Create an Quantum Inspire account if you do not have already have one.
+2. Get an API token from the Quantum Inspire website.
+3. With your API token run: 
+```python
+from quantuminspire.credentials import save_account
+save_account('YOUR_API_TOKEN')
+```
+After calling save_account(), your credentials will be stored on disk.
+Those who do not want to save their credentials to disk should use instead:
+```python
+from quantuminspire.credentials import enable_account
+enable_account('YOUR_API_TOKEN')
+```
+and the token will only be active for the session.
+
+After calling save_account() once or enable_account() within your session, token authentication is done automatically
+when creating the Quantum Inpire API object.
+
+For Qiskit users this means:
+```python
+from quantuminspire.qiskit import QI
+QI.set_authentication()
+```
+ProjectQ users do something like:
+```python
+from quantuminspire.api import QuantumInspireAPI
+qi = QuantumInspireAPI()
+```
+To create a token authentication object yourself using the stored token you do:
+```python
+from quantuminspire.credentials import get_token_authentication
+auth = get_token_authentication()
+```
+This `auth` can then be used to initialize the Quantum Inspire API object.
+ ## Known issues
 
 * Authentication for the Quantum Inspire platform is currently password only; this
   will change to API-token based authentication in the near future;

--- a/docs/example_projectq_entangle.py
+++ b/docs/example_projectq_entangle.py
@@ -11,7 +11,7 @@ from projectq.backends import ResourceCounter
 from projectq.ops import CNOT, H, Measure, All
 from projectq.setups import restrictedgateset
 
-from quantuminspire.credentials import load_token, get_token_authentication, get_basic_authentication
+from quantuminspire.credentials import load_account, get_token_authentication, get_basic_authentication
 from quantuminspire.api import QuantumInspireAPI
 from quantuminspire.projectq.backend_qx import QIBackend
 
@@ -21,7 +21,7 @@ QI_PASSWORD = os.getenv('QI_PASSWORD')
 
 def get_authentication():
     """ Gets the authentication for connecting to the Quantum Inspire API."""
-    token = load_token()
+    token = load_account()
     if token is not None:
         return get_token_authentication(token)
     else:

--- a/docs/example_projectq_grover.py
+++ b/docs/example_projectq_grover.py
@@ -12,7 +12,7 @@ from projectq.meta import Compute, Control, Loop, Uncompute
 from projectq.ops import CNOT, CZ, All, H, Measure, Toffoli, X, Z
 from projectq.setups import restrictedgateset
 
-from quantuminspire.credentials import load_token, get_token_authentication, get_basic_authentication
+from quantuminspire.credentials import load_account, get_token_authentication, get_basic_authentication
 from quantuminspire.api import QuantumInspireAPI
 from quantuminspire.projectq.backend_qx import QIBackend
 
@@ -91,7 +91,7 @@ def alternating_bits_oracle(eng, qubits, output):
 
 def get_authentication():
     """ Gets the authentication for connecting to the Quantum Inspire API."""
-    token = load_token()
+    token = load_account()
     if token is not None:
         return get_token_authentication(token)
     else:

--- a/docs/example_qiskit_entangle.py
+++ b/docs/example_qiskit_entangle.py
@@ -15,7 +15,7 @@ Copyright 2018-19 QuTech Delft. Licensed under the Apache License, Version 2.0.
 """
 import os
 from getpass import getpass
-from quantuminspire.credentials import load_token, get_token_authentication, get_basic_authentication
+from quantuminspire.credentials import load_account, get_token_authentication, get_basic_authentication
 
 from qiskit.validation.base import Obj
 from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit
@@ -29,7 +29,7 @@ QI_PASSWORD = os.getenv('QI_PASSWORD')
 
 def get_authentication():
     """ Gets the authentication for connecting to the Quantum Inspire API."""
-    token = load_token()
+    token = load_account()
     if token is not None:
         return get_token_authentication(token)
     else:

--- a/src/quantuminspire/api.py
+++ b/src/quantuminspire/api.py
@@ -25,14 +25,16 @@ import coreapi
 from coreapi.auth import TokenAuthentication
 from coreapi.exceptions import CoreAPIException, ErrorMessage
 
-from quantuminspire.credentials import load_token
+from quantuminspire.credentials import load_account
 from quantuminspire.exceptions import ApiError
 from quantuminspire.job import QuantumInspireJob
+
+QI_URL = 'https://api.quantum-inspire.com'
 
 
 class QuantumInspireAPI:
 
-    def __init__(self, base_uri: str, authentication: Optional[coreapi.auth.AuthBase] = None,
+    def __init__(self, base_uri: str = QI_URL, authentication: Optional[coreapi.auth.AuthBase] = None,
                  project_name: Optional[str] = None,
                  coreapi_client_class: Type[coreapi.Client] = coreapi.Client) -> None:
         """ Python interface to the Quantum Inspire API (Application Programmer Interface).
@@ -74,11 +76,11 @@ class QuantumInspireAPI:
                       loaded or the schema could not be loaded.
         """
         if authentication is None:
-            token = load_token()
+            token = load_account()
             if token is not None:
                 authentication = TokenAuthentication(token, scheme="token")
             else:
-                raise ApiError('No credentials have been provided')
+                raise ApiError('No credentials have been provided or found on disk')
         self.__client = coreapi_client_class(auth=authentication)
         self.project_name = project_name
         self.base_uri = base_uri

--- a/src/tests/quantuminspire/test_api.py
+++ b/src/tests/quantuminspire/test_api.py
@@ -99,8 +99,8 @@ class TestQuantumInspireAPI(TestCase):
         expected_token = 'secret'
         json.load = MagicMock()
         json.load.return_value = {'token': expected_token}
-        os.getenv = MagicMock()
-        os.getenv.return_value = expected_token
+        os.environ.get = MagicMock()
+        os.environ.get.return_value = expected_token
         expected = 'schema/'
         base_url = 'https://api.mock.test.com/'
         url = ''.join([base_url, expected])
@@ -113,8 +113,8 @@ class TestQuantumInspireAPI(TestCase):
         expected_token = 'secret'
         json.load = MagicMock()
         json.load.return_value = {'wrong_key': expected_token}
-        os.getenv = MagicMock()
-        os.getenv.return_value = None
+        os.environ.get = MagicMock()
+        os.environ.get.return_value = None
         expected = 'schema/'
         base_url = 'https://api.mock.test.com/'
         url = ''.join([base_url, expected])


### PR DESCRIPTION
* More IBM like interface. Instead of <operation>_token, the interface now uses <operation>_account.
* Added enable_account (to set the environment during the session), delete_account, store_account (prevent overwriting earlier stored token), reversed the load order of load_account: first environment, second from file.
* Added unittests for the new functionality
* Prepared the README.md with a paragraph "Configure your token credentials for Quantum Inspire (expected soon)" how to use the token credentials in quantum inspire.
* Adjusted the examples to use the new interface (load_account instead of load_token)