### PR TITLE
[DEM-959] Validate usage of classical bits after measurement

### DIFF
--- a/src/quantuminspire/qiskit/circuit_parser.py
+++ b/src/quantuminspire/qiskit/circuit_parser.py
@@ -575,7 +575,7 @@ class CircuitToString:
         pass
 
     @staticmethod
-    def _get_mask_data(mask: int) -> Tuple[int, int]:
+    def get_mask_data(mask: int) -> Tuple[int, int]:
         """ A mask is a continuous set of 1-bits with a certain length. This method returns the lowest bit of
             the mask and the length of the mask.
             Examples:
@@ -586,6 +586,8 @@ class CircuitToString:
             10000000, lowest mask bit = 7, mask_length = 1
         """
         # Precondition: mask != 0
+        if mask == 0:
+            return -1, 0
         mask_length = 0
         bit_value = 1
         bit_nr = 0
@@ -631,7 +633,7 @@ class CircuitToString:
         mask = int(conditional.mask, 16)
         if mask == 0:
             raise ApiError('Conditional statement {} without a mask'.format(instruction.name.lower()))
-        lowest_mask_bit, mask_length = self._get_mask_data(mask)
+        lowest_mask_bit, mask_length = self.get_mask_data(mask)
         val = int(conditional.val, 16)
         masked_val = mask & val
 

--- a/src/tests/quantuminspire/qiskit/test_backend_qx.py
+++ b/src/tests/quantuminspire/qiskit/test_backend_qx.py
@@ -302,7 +302,8 @@ class TestQiSimulatorPy(unittest.TestCase):
     def test_validate_operation_after_measure(self):
         with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()):
             simulator = QuantumInspireBackend(Mock(), Mock())
-            instructions = [{'name': 'CX', 'qubits': [0, 1]}, {'name': 'measure', 'qubits': [0]},
+            instructions = [{'name': 'CX', 'qubits': [0, 1]},
+                            {'memory': [0], 'name': 'measure', 'qubits': [0]},
                             {'name': 'X', 'qubits': [0]}]
             job_dict = self._basic_qobj_dictionary
             job_dict['experiments'][0]['instructions'] = instructions
@@ -312,7 +313,8 @@ class TestQiSimulatorPy(unittest.TestCase):
     def test_no_operation_after_measure_cx_gate(self):
         with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()):
             simulator = QuantumInspireBackend(Mock(), Mock())
-            instructions = [{'name': 'X', 'qubits': [1]}, {'name': 'measure', 'qubits': [0]},
+            instructions = [{'name': 'X', 'qubits': [1]},
+                            {'memory': [0], 'name': 'measure', 'qubits': [0]},
                             {'name': 'CX', 'qubits': [0, 1]}]
             job_dict = self._basic_qobj_dictionary
             job_dict['experiments'][0]['instructions'] = instructions
@@ -326,7 +328,7 @@ class TestQiSimulatorPy(unittest.TestCase):
         api.execute_qasm_async.return_value = 42
         simulator = QuantumInspireBackend(api, Mock())
         instructions = [{'name': 'h', 'params': [], 'texparams': [], 'qubits': [0]},
-                        {'name': 'measure', 'qubits': [0], 'memory': [0]},
+                        {'memory': [0], 'name': 'measure', 'qubits': [0]},
                         {'name': 'h', 'params': [], 'texparams': [], 'qubits': [1]}]
         qobj_dict = self._basic_qobj_dictionary
         qobj_dict['experiments'][0]['instructions'] = instructions

--- a/src/tests/quantuminspire/qiskit/test_circuit_parser.py
+++ b/src/tests/quantuminspire/qiskit/test_circuit_parser.py
@@ -7,6 +7,7 @@ from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.compiler import assemble, transpile
 from qiskit.assembler.run_config import RunConfig
 from qiskit.qobj import QobjHeader
+from quantuminspire.qiskit.circuit_parser import CircuitToString
 from quantuminspire.qiskit.backend_qx import QuantumInspireBackend
 from quantuminspire.exceptions import ApiError
 
@@ -558,3 +559,39 @@ class TestQiCircuitToString(unittest.TestCase):
                          'params': [-np.pi / 2]}]
         self.assertRaisesRegex(ApiError, 'Conditional not found: reg_idx = 2',
                                self._generate_cqasm_from_instructions, instructions, 2)
+
+    def test_get_mask_data(self):
+        mask = 0
+        lowest_mask_bit, mask_length = CircuitToString.get_mask_data(mask)
+        self.assertEqual(lowest_mask_bit, -1)
+        self.assertEqual(mask_length, 0)
+
+        mask = 56
+        lowest_mask_bit, mask_length = CircuitToString.get_mask_data(mask)
+        self.assertEqual(lowest_mask_bit, 3)
+        self.assertEqual(mask_length, 3)
+
+        mask = 1
+        lowest_mask_bit, mask_length = CircuitToString.get_mask_data(mask)
+        self.assertEqual(lowest_mask_bit, 0)
+        self.assertEqual(mask_length, 1)
+
+        mask = 255
+        lowest_mask_bit, mask_length = CircuitToString.get_mask_data(mask)
+        self.assertEqual(lowest_mask_bit, 0)
+        self.assertEqual(mask_length, 8)
+
+        mask = 510
+        lowest_mask_bit, mask_length = CircuitToString.get_mask_data(mask)
+        self.assertEqual(lowest_mask_bit, 1)
+        self.assertEqual(mask_length, 8)
+
+        mask = 128
+        lowest_mask_bit, mask_length = CircuitToString.get_mask_data(mask)
+        self.assertEqual(lowest_mask_bit, 7)
+        self.assertEqual(mask_length, 1)
+
+        mask = 192
+        lowest_mask_bit, mask_length = CircuitToString.get_mask_data(mask)
+        self.assertEqual(lowest_mask_bit, 6)
+        self.assertEqual(mask_length, 2)


### PR DESCRIPTION
* Adjusted validation method in qiskit backend_qx (__validate_no_usage_after_measure)
  * docstring was not correct
  * added a check that measured memory bits are not used later on as a condition in a binary controlled gate. Because in FSP simulation measurements are not done until the end, so we can't make usage of measured classical bits to influence the outcome of a circuit yet.
* Unittests added
