### PR TITLE
[DEM-944] fsp vs non-fsp in qiskit

### DIFF
--- a/src/quantuminspire/api.py
+++ b/src/quantuminspire/api.py
@@ -473,7 +473,7 @@ class QuantumInspireAPI:
         }
         if not full_state_projection and self.enable_fsp_warning:
             logger.warning("Your experiment can not be optimized and may take longer to execute, "
-                          "see https://www.quantum-inspire.com/kbase/optimization-of-simulations/ for details.")
+                           "see https://www.quantum-inspire.com/kbase/optimization-of-simulations/ for details.")
         return OrderedDict(self._action(['jobs', 'create'], params=payload))
 
     #  results  #

--- a/src/quantuminspire/api.py
+++ b/src/quantuminspire/api.py
@@ -16,7 +16,7 @@ limitations under the License.
 """
 
 import itertools
-import warnings
+import logging
 import time
 import uuid
 from typing import Type, List, Dict, Union, Optional, Any
@@ -31,6 +31,7 @@ from quantuminspire.exceptions import ApiError, AuthenticationError
 from quantuminspire.job import QuantumInspireJob
 
 QI_URL = 'https://api.quantum-inspire.com'
+logger = logging.getLogger(__name__)
 
 
 class QuantumInspireAPI:
@@ -115,7 +116,7 @@ class QuantumInspireAPI:
 
     def show_fsp_warning(self, enable: bool = True) -> None:
         """ The warning that is printed when a non-FSP (full state projection) job is about to run can be controlled,
-        i.e. enabled or disabled via this method.
+            i.e. enabled or disabled via this method.
 
         Args:
             enable: when True the fsp-warning is shown, otherwise not.
@@ -471,7 +472,7 @@ class QuantumInspireAPI:
             'user_data': user_data
         }
         if not full_state_projection and self.enable_fsp_warning:
-            warnings.warn("Your experiment can not be optimized and may take longer to execute, "
+            logger.warning("Your experiment can not be optimized and may take longer to execute, "
                           "see https://www.quantum-inspire.com/kbase/optimization-of-simulations/ for details.")
         return OrderedDict(self._action(['jobs', 'create'], params=payload))
 

--- a/src/quantuminspire/api.py
+++ b/src/quantuminspire/api.py
@@ -16,6 +16,7 @@ limitations under the License.
 """
 
 import itertools
+import warnings
 import time
 import uuid
 from typing import Type, List, Dict, Union, Optional, Any
@@ -85,6 +86,7 @@ class QuantumInspireAPI:
         self.__client = coreapi_client_class(auth=authentication)
         self.project_name = project_name
         self.base_uri = base_uri
+        self.enable_fsp_warning = True
         try:
             self._load_schema()
         except (CoreAPIException, TypeError) as ex:
@@ -110,6 +112,9 @@ class QuantumInspireAPI:
             The resulting data from the get-request. The structure of the data depends on the request.
         """
         return self.__client.get(uri_path)
+
+    def show_fsp_warning(self, enable: bool = True) -> None:
+        self.enable_fsp_warning = enable
 
     def _action(self, action: List[str], params: Optional[Dict[str, Any]] = None) -> Any:
         """ Adapter for performing an action on an object via the Quantum Inspire API.
@@ -458,6 +463,9 @@ class QuantumInspireAPI:
             'full_state_projection': full_state_projection,
             'user_data': user_data
         }
+        if not full_state_projection and self.enable_fsp_warning:
+            warnings.warn("Your experiment can not be optimized and may take longer to execute, "
+                          "see https://www.quantum-inspire.com/kbase/optimization-of-simulations/ for details.")
         return OrderedDict(self._action(['jobs', 'create'], params=payload))
 
     #  results  #

--- a/src/quantuminspire/api.py
+++ b/src/quantuminspire/api.py
@@ -114,6 +114,13 @@ class QuantumInspireAPI:
         return self.__client.get(uri_path)
 
     def show_fsp_warning(self, enable: bool = True) -> None:
+        """ The warning that is printed when a non-FSP (full state projection) job is about to run can be controlled,
+        i.e. enabled or disabled via this method.
+
+        Args:
+            enable: when True the fsp-warning is shown, otherwise not.
+
+        """
         self.enable_fsp_warning = enable
 
     def _action(self, action: List[str], params: Optional[Dict[str, Any]] = None) -> Any:

--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -278,7 +278,7 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
         return fsp
 
     @staticmethod
-    def __validate_unsupported_measurements(experiment: QasmQobjExperiment):
+    def __validate_unsupported_measurements(experiment: QasmQobjExperiment) -> None:
         """ When using non-FSP (not full state projection) certain measurements cannot be handled correctly because
             cQASM isn't as flexible as Qiskit in measuring to specific classical bits.
             Therefore some Qiskit constructions are not supported in QI:
@@ -291,7 +291,7 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
         Raises:
             QisKitBackendError: When the circuit contains an invalid non-FSP measurement
         """
-        measurements = []
+        measurements: List[List[int]] = []
         for instruction in experiment.instructions:
             if instruction.name == 'measure':
                 for q, m in measurements:

--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 """
 import io
-import logging
 import json
 import uuid
 import numpy as np
@@ -37,7 +36,6 @@ from quantuminspire.api import QuantumInspireAPI
 from quantuminspire.exceptions import QisKitBackendError
 from quantuminspire.job import QuantumInspireJob
 from quantuminspire.version import __version__ as quantum_inspire_version
-logger = logging.getLogger(__name__)
 
 
 class QuantumInspireBackend(BaseBackend):  # type: ignore

--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -225,9 +225,10 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
 
     def __validate_number_of_clbits(self, experiment: QasmQobjExperiment) -> None:
         """ Checks whether the number of classical bits has a value cQASM can support.
+
             1. When number of classical bits is less than 1 an error is raised.
-            2. When binary controlled gates are used and the number of classical registers >
-            number of classical registers an error is raised.
+            2. When binary controlled gates are used and the number of classical registers > number of classical
+            registers an error is raised.
                 When using binary controlled gates in Qiskit, we can have something like:
                 q = QuantumRegister(2)
                 c = ClassicalRegister(4)
@@ -272,9 +273,8 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
         for instruction in experiment.instructions:
             if instruction.name == 'measure':
                 measurement_found = True
-            else:
-                if measurement_found:
-                    fsp = False
+            elif measurement_found:
+                fsp = False
         return fsp
 
     @staticmethod
@@ -282,6 +282,7 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
         """ When using non-FSP (not full state projection) certain measurements cannot be handled correctly because
             cQASM isn't as flexible as Qiskit in measuring to specific classical bits.
             Therefore some Qiskit constructions are not supported in QI:
+
             1. When a quantum register is measured to different classical registers
             2. When a classical register is used for the measurement of more than one quantum register
 

--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -103,7 +103,7 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
         Returns:
             A job that has been submitted.
         """
-        self.__validate(qobj)
+        self.__validate_number_of_shots(qobj)
         number_of_shots = qobj.config.shots
 
         identifier = uuid.uuid1()
@@ -111,7 +111,14 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
         project = self.__api.create_project(project_name, number_of_shots, self.__backend)
         experiments = qobj.experiments
         job = QIJob(self, str(project['id']), self.__api)
-        [self._submit_experiment(experiment, number_of_shots, project=project) for experiment in experiments]
+        for experiment in experiments:
+            self.__validate_number_of_clbits(experiment)
+            full_state_projection = self.__validate_full_state_projection(experiment)
+            if not full_state_projection:
+                QuantumInspireBackend.__validate_non_fsp_measurements(experiment)
+            self._submit_experiment(experiment, number_of_shots, project=project,
+                                    full_state_projection=full_state_projection)
+
         job.experiments = experiments
         return job
 
@@ -134,16 +141,17 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
         return QIJob(self, job_id, self.__api)
 
     @staticmethod
-    def _generate_cqasm(experiment: QasmQobjExperiment) -> str:
+    def _generate_cqasm(experiment: QasmQobjExperiment, full_state_projection: bool = True) -> str:
         """ Generates the cQASM from the Qiskit experiment.
 
         Args:
             experiment: The experiment that contains instructions to be converted to cQASM.
+            full_state_projection: When False, the experiment is not suitable for full state projection
 
         Returns:
             The cQASM code that can be sent to the Quantum Inspire API.
         """
-        parser = CircuitToString()
+        parser = CircuitToString(full_state_projection)
         number_of_qubits = experiment.header.n_qubits
         instructions = experiment.instructions
         with io.StringIO() as stream:
@@ -155,14 +163,16 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
             return stream.getvalue()
 
     def _submit_experiment(self, experiment: QasmQobjExperiment, number_of_shots: int,
-                           project: Optional[Dict[str, Any]] = None) -> QuantumInspireJob:
-        compiled_qasm = self._generate_cqasm(experiment)
+                           project: Optional[Dict[str, Any]] = None,
+                           full_state_projection: bool = True) -> QuantumInspireJob:
+        compiled_qasm = self._generate_cqasm(experiment, full_state_projection=full_state_projection)
         measurements = self._collect_measurements(experiment)
         user_data = {'name': experiment.header.name, 'memory_slots': experiment.header.memory_slots,
                      'creg_sizes': experiment.header.creg_sizes, 'measurements': measurements}
         job_id = self.__api.execute_qasm_async(compiled_qasm, backend_type=self.__backend,
                                                number_of_shots=number_of_shots, project=project,
-                                               job_name=experiment.header.name, user_data=json.dumps(user_data))
+                                               job_name=experiment.header.name, user_data=json.dumps(user_data),
+                                               full_state_projection=full_state_projection)
         return job_id
 
     def get_experiment_results(self, qi_job: QIJob) -> List[ExperimentResult]:
@@ -199,18 +209,6 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
             experiment_results.append(ExperimentResult(**experiment_result_dictionary))
         return experiment_results
 
-    def __validate(self, job: QasmQobj) -> None:
-        """ Validates the number of shots, classical bits and compiled Qiskit circuits.
-
-        Args:
-            job: The quantum job with the Qiskit algorithm and quantum inspire backend.
-        """
-        QuantumInspireBackend.__validate_number_of_shots(job)
-
-        for experiment in job.experiments:
-            self.__validate_number_of_clbits(experiment)
-            QuantumInspireBackend.__validate_no_usage_after_measure(experiment)
-
     @staticmethod
     def __validate_number_of_shots(job: QasmQobj) -> None:
         """ Checks whether the number of shots has a valid value.
@@ -226,7 +224,18 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
             raise QisKitBackendError('Invalid shots (number_of_shots={})'.format(number_of_shots))
 
     def __validate_number_of_clbits(self, experiment: QasmQobjExperiment) -> None:
-        """ Checks whether the number of classical bits has a valid value.
+        """ Checks whether the number of classical bits has a value cQASM can support.
+            1. When number of classical bits is less than 1 an error is raised.
+            2. When binary controlled gates are used and the number of classical registers >
+            number of classical registers an error is raised.
+                When using binary controlled gates in Qiskit, we can have something like:
+                q = QuantumRegister(2)
+                c = ClassicalRegister(4)
+                circuit = QuantumCircuit(q, c)
+                circuit.h(q[0]).c_if(c, 15)
+
+                Because cQASM has the same number of classical registers as qubits (2 in this case),
+                this circuit cannot be translated to valid cQASM.
 
         Args:
             experiment: The experiment with gate operations and header.
@@ -248,41 +257,47 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
                                                  " number of qubits when using conditional gate operations")
 
     @staticmethod
-    def __validate_no_usage_after_measure(experiment: QasmQobjExperiment) -> None:
-        """ When using FSP (full state projection) certain instructions cannot be handled correctly because
-            intermediate measurements are not taking place in FSP. The measurements are postponed until the end of the
-            program.
-            Therefore some constructions are currently not supported:
-            1. When qubits are used again after being measured.
-            2. When conditional gate operations (binary controlled gates) are done based on previously measured
-               classical bits
+    def __validate_full_state_projection(experiment: QasmQobjExperiment) -> bool:
+        """ When using FSP (full state projection) measurment instructions cannot be handled correctly.
+            Therefore FSP is not supported when measurements are found.
+
+        Args:
+            experiment: The experiment with gate operations and header.
+
+        Returns
+            True: When the experiment supports FSP.
+            False: When the experiment doesn't supports FSP.
+        """
+        for instruction in experiment.instructions:
+            if instruction.name == 'measure':
+                return False
+        return True
+
+    @staticmethod
+    def __validate_non_fsp_measurements(experiment: QasmQobjExperiment):
+        """ When using non-FSP (not full state projection) certain measurements cannot be handled correctly because
+            cQASM isn't as flexible as Qiskit in measuring to specific classical bits.
+            Therefore some Qiskit constructions are not supported in QI:
+            1. When a quantum register is measured to different classical registers
+            2. When a classical register is used for the measurement of more than one quantum register
 
         Args:
             experiment: The experiment with gate operations and header.
 
         Raises:
-            QisKitBackendError: When a construction is used that is not supported.
+            QisKitBackendError: When the circuit contains an invalid non-FSP measurement
         """
-        measured_qubits = []
-        memory_bits = []
+        measurements = []
         for instruction in experiment.instructions:
             if instruction.name == 'measure':
-                for qubit in instruction.qubits:
-                    measured_qubits.append(qubit)
-                for qubit in instruction.memory:
-                    memory_bits.append(qubit)
-            else:
-                if hasattr(instruction, 'qubits'):
-                    for qubit in instruction.qubits:
-                        if qubit in measured_qubits:
-                            raise QisKitBackendError('Operation on qubit {} after measurement'.format(qubit))
-                if instruction.name == 'bfunc':
-                    lowest_mask_bit, mask_length = CircuitToString.get_mask_data(int(instruction.mask, 16))
-                    for bit in range(mask_length):
-                        mask_bit = bit + lowest_mask_bit
-                        if mask_bit in memory_bits:
-                            raise QisKitBackendError('Usage of binary controlled gates where the condition consists of '
-                                                     'earlier measured binary registers is currently not supported')
+                for q, m in measurements:
+                    if q == instruction.qubits[0] and m != instruction.memory[0]:
+                        raise QisKitBackendError('Measurement of qubit {} to different classical registers '
+                                                 'is not supported'.format(q))
+                    if q != instruction.qubits[0] and m == instruction.memory[0]:
+                        raise QisKitBackendError('Measurement of different qubits to the same classical register {0} '
+                                                 'is not supported'.format(m))
+                measurements.append([instruction.qubits[0], instruction.memory[0]])
 
     @staticmethod
     def _collect_measurements(experiment: QasmQobjExperiment) -> Dict[str, Any]:

--- a/src/quantuminspire/qiskit/circuit_parser.py
+++ b/src/quantuminspire/qiskit/circuit_parser.py
@@ -26,8 +26,9 @@ from quantuminspire.exceptions import ApiError
 class CircuitToString:
     """ Contains the translational elements to convert the Qiskit circuits to cQASM code."""
 
-    def __init__(self) -> None:
+    def __init__(self, full_state_projection: bool = True) -> None:
         self.bfunc_instructions: List[QasmQobjInstruction] = []
+        self.full_state_projection = full_state_projection
 
     @staticmethod
     def _gate_not_supported(_stream: StringIO, instruction: QasmQobjInstruction, _binary_control: Optional[str] = None)\
@@ -559,16 +560,16 @@ class CircuitToString:
         """
         pass
 
-    @staticmethod
-    def _measure(stream: StringIO, instruction: QasmQobjInstruction) -> None:
-        """ Translates the measure element. No cQASM is added for this gate.
+    def _measure(self, stream: StringIO, instruction: QasmQobjInstruction) -> None:
+        """ Translates the measure element. No cQASM is added for this gate when FSP is used.
 
         Args:
             stream: The string-io stream to where the resulting cQASM is written.
             instruction: The Qiskit instruction to translate to cQASM.
 
         """
-        pass
+        if not self.full_state_projection:
+            stream.write('measure q[{0}]\n'.format(*instruction.qubits))
 
     @staticmethod
     def get_mask_data(mask: int) -> Tuple[int, int]:

--- a/src/quantuminspire/qiskit/qi_job.py
+++ b/src/quantuminspire/qiskit/qi_job.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Any
 from qiskit.providers import BaseJob, JobStatus, JobError, JobTimeoutError
 from qiskit.qobj import QasmQobj, QasmQobjExperiment
 from qiskit.result import Result
-from quantuminspire import __version__ as quantum_inspire_version
+from quantuminspire.version import __version__ as quantum_inspire_version
 from quantuminspire.api import QuantumInspireAPI
 
 

--- a/src/tests/quantuminspire/qiskit/test_backend_qx.py
+++ b/src/tests/quantuminspire/qiskit/test_backend_qx.py
@@ -344,6 +344,26 @@ class TestQiSimulatorPy(unittest.TestCase):
             api.get_jobs_from_project.return_value = []
             api.execute_qasm_async.return_value = 42
             simulator = QuantumInspireBackend(api, Mock())
+            instructions = [{'memory': [0], 'name': 'measure', 'qubits': [0]},
+                            {'name': 'cx', 'qubits': [0, 1]},
+                            {'name': 'x', 'qubits': [0]},
+                            {'memory': [1], 'name': 'measure', 'qubits': [1]}]
+            experiment = self._basic_experiment_dictionary
+            experiment['instructions'] = instructions
+            qjob_dict = self._basic_qobj_dictionary
+            qjob_dict['experiments'][0] = experiment
+            qobj = QasmQobj.from_dict(qjob_dict)
+            experiment = qobj.experiments[0]
+            simulator.run(qobj)
+        result_experiment.assert_called_once_with(experiment, 25, project=project, full_state_projection=False)
+
+        with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()) as result_experiment:
+            api = Mock()
+            project = {'id': 42}
+            api.create_project.return_value = project
+            api.get_jobs_from_project.return_value = []
+            api.execute_qasm_async.return_value = 42
+            simulator = QuantumInspireBackend(api, Mock())
             instructions = [{'name': 'cx', 'qubits': [0, 1]},
                             {'name': 'x', 'qubits': [0]},
                             {'memory': [0], 'name': 'measure', 'qubits': [1]}]
@@ -354,7 +374,7 @@ class TestQiSimulatorPy(unittest.TestCase):
             qobj = QasmQobj.from_dict(qjob_dict)
             experiment = qobj.experiments[0]
             simulator.run(qobj)
-        result_experiment.assert_called_once_with(experiment, 25, project=project, full_state_projection=False)
+        result_experiment.assert_called_once_with(experiment, 25, project=project, full_state_projection=True)
 
         with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()) as result_experiment:
             api = Mock()

--- a/src/tests/quantuminspire/qiskit/test_backend_qx.py
+++ b/src/tests/quantuminspire/qiskit/test_backend_qx.py
@@ -317,7 +317,7 @@ class TestQiSimulatorPy(unittest.TestCase):
                                                    ' number of qubits when using conditional gate operations',
                                simulator.run, job)
 
-    def test_for_full_state_projection(self):
+    def test_for_non_fsp_gate_after_measurement(self):
         with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()) as result_experiment:
             api = Mock()
             project = {'id': 42}
@@ -337,6 +337,7 @@ class TestQiSimulatorPy(unittest.TestCase):
             simulator.run(qobj)
         result_experiment.assert_called_once_with(experiment, 25, project=project, full_state_projection=False)
 
+    def test_for_non_fsp_measurements_at_begin_and_end(self):
         with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()) as result_experiment:
             api = Mock()
             project = {'id': 42}
@@ -357,6 +358,7 @@ class TestQiSimulatorPy(unittest.TestCase):
             simulator.run(qobj)
         result_experiment.assert_called_once_with(experiment, 25, project=project, full_state_projection=False)
 
+    def test_for_fsp_measurements_at_end_only(self):
         with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()) as result_experiment:
             api = Mock()
             project = {'id': 42}
@@ -376,6 +378,7 @@ class TestQiSimulatorPy(unittest.TestCase):
             simulator.run(qobj)
         result_experiment.assert_called_once_with(experiment, 25, project=project, full_state_projection=True)
 
+    def test_for_fsp_no_measurements(self):
         with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()) as result_experiment:
             api = Mock()
             project = {'id': 42}


### PR DESCRIPTION
The following general rules are implemented for both Qiskit and ProjectQ (another PR):

* An algorithm without measurements or only measurements at the end (no gates following the measurements) can be executed as full state projection, otherwise it is executed as non-fsp.
* Also in a non-fsp algorithm not more than one different qubits may be measured to a classical bit and a qubit may not be measured to more than one classical bit.
* When a non-fsp algorithm is run the warning as specced in the desired outcome of the ticket [DEM-944] should be printed, according to the acceptance criteria. In api there is a method to enable or disable this warning:

show_fsp_warning(self, enable: bool = True)

[DEM-944]: https://qutech-sd.atlassian.net/browse/DEM-944