### PR TITLE
[DEM-1016] Reuse ancilla qubits

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The software development kit (SDK) for the Quantum Inspire platform consists of:
 * An API for the [Quantum Inspire](https://www.quantum-inspire.com/) platform (the QuantumInspireAPI class);
 * Backends for:
   * the [ProjectQ SDK](https://github.com/ProjectQ-Framework/ProjectQ);
-  * the [QisKit SDK](https://qiskit.org/).
+  * the [Qiskit SDK](https://qiskit.org/).
 
 For more information on Quantum Inspire see
 [https://www.quantum-inspire.com/](https://www.quantum-inspire.com/). Detailed information
@@ -44,7 +44,7 @@ $ cd quantuminspire
 $ pip install .
 ```
 
-This does not install ProjectQ or QisKit, but will install the Quantum Inspire backends for
+This does not install ProjectQ or Qiskit, but will install the Quantum Inspire backends for
 those projects.
 
 If you want to include a specific SDK as a dependency, install with
@@ -54,7 +54,7 @@ If you want to include a specific SDK as a dependency, install with
 $ pip install .[projectq]
 ```
 
-To install both ProjectQ as well as QisKit as a dependency:
+To install both ProjectQ as well as Qiskit as a dependency:
 
 ```
 $ pip install .[qiskit,projectq]
@@ -127,7 +127,7 @@ print(result['histogram'])
 
 ## Configure your token credentials for Quantum Inspire
 
-1. Create an Quantum Inspire account if you do not have already have one.
+1. Create a Quantum Inspire account if you do not already have one.
 2. Get an API token from the Quantum Inspire website.
 3. With your API token run: 
 ```python

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ result = qi.execute_qasm(qasm, backend_type=backend_type, number_of_shots=1024)
 print(result['histogram'])
 ```
 
-## Configure your token credentials for Quantum Inspire (expected soon)
+## Configure your token credentials for Quantum Inspire
 
 1. Create an Quantum Inspire account if you do not have already have one.
 2. Get an API token from the Quantum Inspire website.
@@ -163,10 +163,6 @@ auth = get_token_authentication()
 This `auth` can then be used to initialize the Quantum Inspire API object.
  ## Known issues
 
-* Authentication for the Quantum Inspire platform is currently password only; this
-  will change to API-token based authentication in the near future;
-* It is not possible to simulate algorithms that do not use full state
-  projection through Qiskit / ProjectQ
 * Some test-cases call protected methods
 * Known issues and common questions regarding the Quantum Inspire platform
   can be found in the [FAQ](https://www.quantum-inspire.com/faq/).

--- a/src/quantuminspire/projectq/backend_qx.py
+++ b/src/quantuminspire/projectq/backend_qx.py
@@ -236,7 +236,8 @@ class QIBackend(BasicEngine):  # type: ignore
         if self._is_simulation_backend:
             allocation_entry = next(iter(x for x in self._allocation_map if x[1] == physical_qubit_id), None)
             if allocation_entry is None:
-                raise RuntimeError("Bit position in simulation backend not found for physical bit {0}.".format(physical_qubit_id))
+                raise RuntimeError("Bit position in simulation backend not found for physical bit {0}."
+                                   .format(physical_qubit_id))
             else:
                 return allocation_entry[0]
         else:

--- a/src/quantuminspire/projectq/backend_qx.py
+++ b/src/quantuminspire/projectq/backend_qx.py
@@ -56,6 +56,7 @@ class QIBackend(BasicEngine):  # type: ignore
         self._flushed: bool = False
         """ Because engines are meant to be 'single use' by the way ProjectQ is designed,
         any additional gates received after a FlushGate triggers an exception. """
+        self._clear: bool = True
         self._reset()
         self._num_runs: int = num_runs
         if num_runs < 1:

--- a/src/tests/quantuminspire/projectq/test_backend_qx.py
+++ b/src/tests/quantuminspire/projectq/test_backend_qx.py
@@ -24,9 +24,9 @@ import coreapi
 from collections import OrderedDict
 from unittest.mock import MagicMock, patch
 
-from projectq.meta import LogicalQubitIDTag, get_control_count
-from projectq.ops import (CNOT, CX, CZ, NOT, QFT, All, Allocate, Barrier,
-                          BasicPhaseGate, C, Deallocate, FlushGate, H, Measure,
+from projectq.meta import LogicalQubitIDTag
+from projectq.ops import (CNOT, NOT, Allocate, Barrier,
+                          Deallocate, FlushGate, H, Measure,
                           Ph, Rx, Ry, Rz, S, Sdag, Swap, T, Tdag, Toffoli, X,
                           Y, Z)
 
@@ -43,7 +43,7 @@ class MockApiClient:
                                                                     "number_of_qubits": 26}))
 
 
-class QIBackend_non_protected(QIBackend):
+class QIBackendNonProtected(QIBackend):
 
     @property
     def quantum_inspire_api(self):
@@ -109,10 +109,6 @@ class QIBackend_non_protected(QIBackend):
     def number_of_qubits(self):
         return self._number_of_qubits
 
-    @number_of_qubits.setter
-    def number_of_qubits(self, x):
-        self._number_of_qubits = x
-
     @property
     def max_number_of_qubits(self):
         return self._max_number_of_qubits
@@ -137,11 +133,11 @@ class TestProjectQBackend(unittest.TestCase):
         warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
 
         self.api = MockApiClient()
-        self.qi_backend = QIBackend_non_protected(quantum_inspire_api = self.api)
-        self.qi_verbose_backend = QIBackend_non_protected(quantum_inspire_api=self.api, verbose=2)
+        self.qi_backend = QIBackendNonProtected(quantum_inspire_api=self.api)
+        self.qi_verbose_backend = QIBackendNonProtected(quantum_inspire_api=self.api, verbose=2)
         self.api.get_backend_type = MagicMock(return_value=OrderedDict({"is_hardware_backend": True,
                                                                         "number_of_qubits": 26}))
-        self.qi_hw_backend = QIBackend_non_protected(quantum_inspire_api = self.api)
+        self.qi_hw_backend = QIBackendNonProtected(quantum_inspire_api=self.api)
 
     def test_init_has_correct_values(self):
         self.assertIsInstance(self.qi_backend.qasm, str)
@@ -154,7 +150,7 @@ class TestProjectQBackend(unittest.TestCase):
         coreapi.Client.get = MagicMock()
         result = {"is_hardware_backend": False, "number_of_qubits": 26}
         coreapi.Client.action = MagicMock(return_value=result)
-        self.qi_backend_no_api = QIBackend_non_protected()
+        self.qi_backend_no_api = QIBackendNonProtected()
         self.assertIsInstance(self.qi_backend_no_api.qasm, str)
         self.assertNotEqual(self.qi_backend_no_api.quantum_inspire_api, None)
         self.assertIsNone(self.qi_backend_no_api.backend_type)


### PR DESCRIPTION
* When the maximum number of qubits for the simulator is reached, de-allocate qubits are reused.
* When a qubit is reused, a prep_z is added for this qubit. This prep_z is composed of a measurement of this qubit, followed by a conditional X on this qubit
* The allocation and deallocation is adjusted, so we keep track of the allocation of a physical bit to a simulation bit.
* When the backend is a hardware backend, the ancilla bits are NOT re-used.
