### PR TITLE
[DEM-1172] Endless waiting for job

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,11 @@ display
 backend_type = qi.get_backend_type_by_name('QX single-node simulator')
 result = qi.execute_qasm(qasm, backend_type=backend_type, number_of_shots=1024)
 
-print(result['histogram'])
+if result.get('histogram', {}):
+    print(result['histogram'])
+else:
+    reason = result.get('raw_text', 'No reason in result structure.')
+    print(f'Result structure does not contain proper histogram data. {reason}')
 ```
 
 ## Configure your token credentials for Quantum Inspire

--- a/src/quantuminspire/api.py
+++ b/src/quantuminspire/api.py
@@ -19,7 +19,7 @@ import itertools
 import logging
 import time
 import uuid
-from typing import Type, List, Dict, Union, Optional, Any
+from typing import Type, List, Dict, Union, Optional, Any, Tuple
 from collections import OrderedDict
 from urllib.parse import urljoin
 import coreapi
@@ -515,6 +515,7 @@ class QuantumInspireAPI:
                 | measurement_mask (int)            | (deprecated, unused) The measurement mask.
                 | quantum_states_url (str)          | Url to get a list of quantum states.
                 | measurement_register_url (str)    | Url to get a list of measurement register.
+                | calibration                       | Calibration information.
         """
         try:
             result = self._action(['results', 'read'], params={'id': result_id})
@@ -748,7 +749,7 @@ class QuantumInspireAPI:
 
     @staticmethod
     def _wait_for_completed_job(quantum_inspire_job: QuantumInspireJob, collect_max_tries: Optional[int] = None,
-                                sec_retry_delay: float = 0.5) -> bool:
+                                sec_retry_delay: float = 0.5) -> Tuple[bool, str]:
         """ Delays the process and requests the job status. The waiting loop is broken when the job status is
             completed or cancelled, or when the maximum number of tries is set and has been reached.
 
@@ -759,17 +760,34 @@ class QuantumInspireAPI:
             sec_retry_delay: The time delay in between job status checks in seconds.
 
         Returns:
-            True if the job result could be collected else False.
+            True if the job result could be collected else False in hte first part of the tuple.
+            The latter part of the tuple contains an (error)message.
         """
         attempts = itertools.count() if collect_max_tries is None else range(collect_max_tries)
         for _ in attempts:
             time.sleep(sec_retry_delay)
             status = quantum_inspire_job.check_status()
             if status == 'COMPLETE':
-                return True
+                return True, 'Job completed.'
             if status == 'CANCELLED':
-                return False
-        return False
+                return False, 'Failed getting result: job cancelled.'
+        return False, 'Failed getting result: timeout reached.'
+
+    @staticmethod
+    def _generate_error_result(message: str) -> Dict[str, Any]:
+        """Generate an error result object
+
+        Args:
+            message: Reason for the failed job
+
+        Returns:
+            Result object containing an empty histogram and an error message
+        """
+        result_obj = {
+            'histogram': {},
+            'raw_text': message
+        }
+        return result_obj
 
     def execute_qasm(self, qasm: str, backend_type: Optional[Union[Dict[str, Any], int, str]] = None,
                      number_of_shots: int = 256, collect_tries: Optional[int] = None,
@@ -800,8 +818,8 @@ class QuantumInspireAPI:
             full_state_projection: Do not use full state projection when set to False (default is True).
 
         Returns:
-            The results of the executed cQASM if successful else an empty dictionary if
-            the results could not be collected within the given number of tries.
+            The results of the executed cQASM if successful else an error result if
+            the results could not be collected within the given number of tries or the job failed.
             See `get_result` for a description of the result properties.
         """
         delete_project_afterwards = self.project_name is None
@@ -813,8 +831,9 @@ class QuantumInspireAPI:
                                                           identifier=identifier,
                                                           full_state_projection=full_state_projection)
 
-            has_results = self._wait_for_completed_job(quantum_inspire_job, collect_tries)
-            return OrderedDict(quantum_inspire_job.retrieve_results()) if has_results else OrderedDict()
+            has_results, message = self._wait_for_completed_job(quantum_inspire_job, collect_tries)
+            return OrderedDict(quantum_inspire_job.retrieve_results()) if has_results else \
+                OrderedDict(self._generate_error_result(message))
         finally:
             if delete_project_afterwards and quantum_inspire_job is not None:
                 project_identifier = quantum_inspire_job.get_project_identifier()

--- a/src/quantuminspire/job.py
+++ b/src/quantuminspire/job.py
@@ -39,7 +39,8 @@ class QuantumInspireJob:
         """ Checks the execution status of the job.
 
         Returns:
-            The status of the job.
+            The status of the job. Can be: 'NEW', 'RUNNING', 'COMPLETE', 'CANCELLED'
+            (status values defined in:api-router/apirouter/jobs/constants.py)
         """
         job = self.__api.get_job(self.__job_identifier)
         return str(job['status'])

--- a/src/quantuminspire/job.py
+++ b/src/quantuminspire/job.py
@@ -40,7 +40,6 @@ class QuantumInspireJob:
 
         Returns:
             The status of the job. Can be: 'NEW', 'RUNNING', 'COMPLETE', 'CANCELLED'
-            (status values defined in:api-router/apirouter/jobs/constants.py)
         """
         job = self.__api.get_job(self.__job_identifier)
         return str(job['status'])

--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -19,7 +19,6 @@ import io
 import json
 import uuid
 from collections import defaultdict, OrderedDict, Counter
-from itertools import combinations
 from typing import Dict, List, Tuple, Optional, Any
 
 import numpy as np

--- a/src/quantuminspire/qiskit/qi_job.py
+++ b/src/quantuminspire/qiskit/qi_job.py
@@ -1,7 +1,8 @@
 import time
 from typing import List, Optional, Any
 
-from qiskit.providers import BaseJob, JobStatus, JobError, JobTimeoutError
+from qiskit.providers import BaseJob, JobError, JobTimeoutError
+from qiskit.providers.jobstatus import JobStatus, JOB_FINAL_STATES
 from qiskit.qobj import QasmQobj, QasmQobjExperiment
 from qiskit.result import Result
 from quantuminspire.version import __version__ as quantum_inspire_version
@@ -64,7 +65,7 @@ class QIJob(BaseJob):  # type: ignore
             QisKitBackendError: If an error occurs during simulation.
         """
         start_time = time.time()
-        while self.status() != JobStatus.DONE:
+        while self.status() not in JOB_FINAL_STATES:
             elapsed_time = time.time() - start_time
             if timeout is not None and elapsed_time > timeout:
                 raise JobTimeoutError('Failed getting result: timeout reached.')

--- a/src/tests/quantuminspire/test_api.py
+++ b/src/tests/quantuminspire/test_api.py
@@ -1004,6 +1004,16 @@ class TestQuantumInspireAPI(TestCase):
         is_completed = api._wait_for_completed_job(quantum_inspire_job, collect_max_tries, sec_retry_delay=0.0)
         self.assertFalse(is_completed)
 
+    def test_wait_for_cancelled_job_returns_false(self):
+        job_id = 509
+        expected_payload = {'id': job_id}
+        self.coreapi_client.handlers['jobs'] = partial(self.__mock_job_handler, expected_payload, 'read',
+                                                       status='CANCELLED')
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        quantum_inspire_job = QuantumInspireJob(api, job_id)
+        is_completed = api._wait_for_completed_job(quantum_inspire_job)
+        self.assertFalse(is_completed)
+
     def __fake_backendtype_handler(self, mock_api, document, keys, params=None, validate=None,
                                    overrides=None, action=None, encoding=None, transform=None, call_mock=None):
         if call_mock:
@@ -1101,7 +1111,7 @@ class TestQuantumInspireAPI(TestCase):
         return OrderedDict([('url', 'https//api.quantum-inspire.com/jobs/509/'),
                             ('name', 'qi-sdk-job-7e37c8fa-a76b-11e8-b5a0-a44cc848f1f2'),
                             ('id', 509),
-                            ('status', 'FAILED'),
+                            ('status', 'CANCELLED'),
                             ('input', 'https//api.quantum-inspire.com/assets/607/'),
                             ('backend', 'https//api.quantum-inspire.com/backends/1/'),
                             ('backend_type', 'https//api.quantum-inspire.com/backendtypes/1/'),
@@ -1109,14 +1119,20 @@ class TestQuantumInspireAPI(TestCase):
                             ('queued_at', '2018-08-24T07:01:21:257557Z'),
                             ('number_of_shots', 1)])
 
-    def __mocks_for_api_execution(self):
-        expected_job_result = self.__fake_job_handler({}, 'read', None, None, ['test', 'read'], {})
+    def __mocks_for_api_execution(self, fake_no_results=False):
+        if fake_no_results:
+            expected_job_result = self.__fake_no_results_job_handler({}, 'read', None, None, ['test', 'read'], {})
+        else:
+            expected_job_result = self.__fake_job_handler({}, 'read', None, None, ['test', 'read'], {})
         self.coreapi_client.getters['mocked_job'] = expected_job_result
         expected_asset = self.__fake_asset_handler({}, 'create', None, None, ['test', 'create'], {})
         self.coreapi_client.getters['171'] = expected_asset
 
         job_mock = Mock()
-        self.coreapi_client.handlers['jobs'] = partial(self.__fake_job_handler, call_mock=job_mock)
+        if fake_no_results:
+            self.coreapi_client.handlers['jobs'] = partial(self.__fake_no_results_job_handler, call_mock=job_mock)
+        else:
+            self.coreapi_client.handlers['jobs'] = partial(self.__fake_job_handler, call_mock=job_mock)
         asset_mock = Mock()
         self.coreapi_client.handlers['assets'] = partial(self.__fake_asset_handler, call_mock=asset_mock)
         backend_mock = Mock()
@@ -1125,6 +1141,14 @@ class TestQuantumInspireAPI(TestCase):
         self.coreapi_client.handlers['projects'] = partial(self.__fake_project_handler_params, call_mock=project_mock)
 
         return expected_job_result, job_mock, asset_mock, backend_mock, project_mock
+
+    def test_execute_qasm_cancelled_job(self):
+        mocks = self.__mocks_for_api_execution(fake_no_results=True)
+        api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
+        qasm = 'version 1.0...'
+        number_of_shots = 1024
+        results = api.execute_qasm(qasm, number_of_shots=number_of_shots, backend_type=1)
+        self.assertEqual(results, OrderedDict())
 
     def test_execute_qasm_different_backend(self):
         mocks = self.__mocks_for_api_execution()

--- a/src/tests/quantuminspire/test_api.py
+++ b/src/tests/quantuminspire/test_api.py
@@ -990,8 +990,9 @@ class TestQuantumInspireAPI(TestCase):
                                                        status='COMPLETE')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
         quantum_inspire_job = QuantumInspireJob(api, job_id)
-        is_completed = api._wait_for_completed_job(quantum_inspire_job, collect_max_tries, sec_retry_delay=0.0)
+        is_completed, message = api._wait_for_completed_job(quantum_inspire_job, collect_max_tries, sec_retry_delay=0.0)
         self.assertTrue(is_completed)
+        self.assertEqual(message, 'Job completed.')
 
     def test_wait_for_completed_job_returns_false(self):
         job_id = 509
@@ -1001,8 +1002,9 @@ class TestQuantumInspireAPI(TestCase):
                                                        status='RUNNING')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
         quantum_inspire_job = QuantumInspireJob(api, job_id)
-        is_completed = api._wait_for_completed_job(quantum_inspire_job, collect_max_tries, sec_retry_delay=0.0)
+        is_completed, message = api._wait_for_completed_job(quantum_inspire_job, collect_max_tries, sec_retry_delay=0.0)
         self.assertFalse(is_completed)
+        self.assertEqual(message, 'Failed getting result: timeout reached.')
 
     def test_wait_for_cancelled_job_returns_false(self):
         job_id = 509
@@ -1011,8 +1013,9 @@ class TestQuantumInspireAPI(TestCase):
                                                        status='CANCELLED')
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
         quantum_inspire_job = QuantumInspireJob(api, job_id)
-        is_completed = api._wait_for_completed_job(quantum_inspire_job)
+        is_completed, message = api._wait_for_completed_job(quantum_inspire_job)
         self.assertFalse(is_completed)
+        self.assertEqual(message, 'Failed getting result: job cancelled.')
 
     def __fake_backendtype_handler(self, mock_api, document, keys, params=None, validate=None,
                                    overrides=None, action=None, encoding=None, transform=None, call_mock=None):
@@ -1148,7 +1151,8 @@ class TestQuantumInspireAPI(TestCase):
         qasm = 'version 1.0...'
         number_of_shots = 1024
         results = api.execute_qasm(qasm, number_of_shots=number_of_shots, backend_type=1)
-        self.assertEqual(results, OrderedDict())
+        self.assertEqual(results['histogram'], {})
+        self.assertEqual(results['raw_text'], 'Failed getting result: job cancelled.')
 
     def test_execute_qasm_different_backend(self):
         mocks = self.__mocks_for_api_execution()


### PR DESCRIPTION
* At two places (api and qi_job) the loop is now also ended when other 'job final states' are received as status.
* Unit tests for these 'final state' status values added.