### PR TITLE
[DEM-1186] stripping spaces and tabs from qasm

### DIFF
--- a/src/quantuminspire/api.py
+++ b/src/quantuminspire/api.py
@@ -918,8 +918,8 @@ class QuantumInspireAPI:
             project_name = self.project_name if self.project_name else 'qi-sdk-project-{}'.format(identifier)
             project = self.create_project(project_name, default_number_of_shots, backend_type)
 
-        qasm = qasm.strip()
-        qasm = re.sub(r'[\t\s]*\n[\s\t]*', r'\n', qasm)
+        qasm = qasm.lstrip()
+        qasm = re.sub(r'[ \t]*\n[ \t]*', r'\n', qasm)
         asset_name = 'qi-sdk-asset-{}'.format(identifier)
         asset = self._create_asset(asset_name, project, qasm)
 

--- a/src/quantuminspire/api.py
+++ b/src/quantuminspire/api.py
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
+import re
 import itertools
 import logging
 import time
@@ -918,6 +918,8 @@ class QuantumInspireAPI:
             project_name = self.project_name if self.project_name else 'qi-sdk-project-{}'.format(identifier)
             project = self.create_project(project_name, default_number_of_shots, backend_type)
 
+        qasm = qasm.strip()
+        qasm = re.sub(r'[\t\s]*\n[\s\t]*', r'\n', qasm)
         asset_name = 'qi-sdk-asset-{}'.format(identifier)
         asset = self._create_asset(asset_name, project, qasm)
 

--- a/src/tests/quantuminspire/test_api.py
+++ b/src/tests/quantuminspire/test_api.py
@@ -1254,8 +1254,8 @@ class TestQuantumInspireAPI(TestCase):
         api = QuantumInspireAPI('FakeURL', self.authentication, coreapi_client_class=self.coreapi_client)
         self.assertIsNone(api.project_name)
 
-        qasm = '  \n version 1.0   \n        qubits 10\n h q[0] \n   measure_z q[0]  \n       \n         \n'
+        qasm = '  \n version 1.0  \n	 	qubits 10\n \n	h q[0] \n 	 measure_z q[0]  \n       \n         \n'
         api.execute_qasm(qasm, collect_tries=1)
 
         asset_call_items = asset_mock.call_args_list[0][1]
-        self.assertEqual('version 1.0\nqubits 10\nh q[0]\nmeasure_z q[0]', asset_call_items['params']['content'])
+        self.assertEqual('version 1.0\nqubits 10\n\nh q[0]\nmeasure_z q[0]\n\n\n', asset_call_items['params']['content'])


### PR DESCRIPTION
* Removing heading and trailing spaces and tabs
* unit test added. Had to add the params-parameter to the mock to store the assets-content
* The prove that a circuit with unindented sub-circuits is running correctly is given in the demo