### PR TITLE
[INS-126] Project names in Qiskit

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -51,7 +51,7 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 #disable=too-few-public-methods,missing-docstring
-disable=too-few-public-methods,missing-docstring,invalid-name,no-self-use
+disable=too-few-public-methods,too-many-public-methods,missing-docstring,invalid-name,no-self-use,too-many-arguments
 #print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 *Note: this SDK is made available as a public beta, please report any
 issues or bugs in the github issue tracker.*
 
-The Quantum Inspire platform allows to execute quantum algorithms using the cQASM language. 
+The Quantum Inspire platform allows to execute quantum algorithms using the cQASM language.
 
 The software development kit (SDK) for the Quantum Inspire platform consists of:
 
@@ -23,15 +23,15 @@ on cQASM can be found in the Quantum Inspire
 The Quantum Inspire SDK can be installed from PyPI via pip:
 
 ```
-$ pip install quantuminspire
+pip install quantuminspire
 ```
 
 In addition, to use Quantum Inspire through Qiskit or ProjectQ, install either or both of
 the qiskit and projectq packages:
 
 ```
-$ pip install qiskit
-$ pip install projectq
+pip install qiskit
+pip install projectq
 ```
 
 ### Installing from source
@@ -39,9 +39,9 @@ $ pip install projectq
 The source for the SDK can also be found at Github. For the default installation execute:
 
 ```
-$ git clone https://github.com/QuTech-Delft/quantuminspire
-$ cd quantuminspire
-$ pip install .
+git clone https://github.com/QuTech-Delft/quantuminspire
+cd quantuminspire
+pip install .
 ```
 
 This does not install ProjectQ or Qiskit, but will install the Quantum Inspire backends for
@@ -51,13 +51,13 @@ If you want to include a specific SDK as a dependency, install with
 (e.g. for the ProjectQ backend):
 
 ```
-$ pip install .[projectq]
+pip install .[projectq]
 ```
 
 To install both ProjectQ as well as Qiskit as a dependency:
 
 ```
-$ pip install .[qiskit,projectq]
+pip install .[qiskit,projectq]
 ```
 
 ## Running
@@ -108,7 +108,7 @@ password = getpass()
 
 server_url = r'https://api.quantum-inspire.com'
 authentication = BasicAuthentication(email, password)
-qi = QuantumInspireAPI(server_url, authentication)
+qi = QuantumInspireAPI(server_url, authentication, 'my-project-name')
 
 qasm = '''version 1.0
 
@@ -129,11 +129,43 @@ else:
     print(f'Result structure does not contain proper histogram data. {reason}')
 ```
 
+## Configure a project name for Quantum Inspire
+
+SDK stores the jobs in a Quantum Inspire project with the name "qi-sdk-project-" concatenated with a unique identifier.
+It is possible to provide a project name yourself. This makes finding the project in the Quantum Inspire web-interface
+easier.
+
+Qiskit users do something like:
+```python
+from coreapi.auth import BasicAuthentication
+from quantuminspire.qiskit import QI
+
+authentication = BasicAuthentication("email", "password")
+QI.set_authentication(authentication, project_name='my-project-name')
+```
+or set the project name separately after setting authentication
+```python
+from coreapi.auth import BasicAuthentication
+from quantuminspire.qiskit import QI
+
+authentication = BasicAuthentication("email", "password")
+QI.set_authentication(authentication)
+QI.set_project_name('my-project-name')
+```
+ProjectQ users set the project name while initializing QuantumInspireAPI:
+```python
+from coreapi.auth import BasicAuthentication
+from quantuminspire.api import QuantumInspireAPI
+
+authentication = BasicAuthentication("email", "password")
+qi_api = QuantumInspireAPI(authentication=authentication, project_name='my-project-name')
+```
+
 ## Configure your token credentials for Quantum Inspire
 
 1. Create a Quantum Inspire account if you do not already have one.
 2. Get an API token from the Quantum Inspire website.
-3. With your API token run: 
+3. With your API token run:
 ```python
 from quantuminspire.credentials import save_account
 save_account('YOUR_API_TOKEN')
@@ -165,15 +197,6 @@ from quantuminspire.credentials import get_token_authentication
 auth = get_token_authentication()
 ```
 This `auth` can then be used to initialize the Quantum Inspire API object.
- ## Known issues
-
-* Some test-cases call protected methods
-* Known issues and common questions regarding the Quantum Inspire platform
-  can be found in the [FAQ](https://www.quantum-inspire.com/faq/).
- 
-## Bug reports
-
-Please submit bug-reports [on the github issue tracker](https://github.com/QuTech-Delft/quantuminspire/issues).
 
 ## Testing
 
@@ -183,6 +206,16 @@ Run all unit tests and collect the code coverage using:
 coverage run --source="./src/quantuminspire" -m unittest discover -s src/tests -t src -v
 coverage report -m
 ```
+
+## Known issues
+
+* Some test-cases call protected methods
+* Known issues and common questions regarding the Quantum Inspire platform
+  can be found in the [FAQ](https://www.quantum-inspire.com/faq/).
+
+## Bug reports
+
+Please submit bug-reports [on the github issue tracker](https://github.com/QuTech-Delft/quantuminspire/issues).
 
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ else:
 
 ## Configure a project name for Quantum Inspire
 
-SDK stores the jobs in a Quantum Inspire project with the name "qi-sdk-project-" concatenated with a unique identifier.
-It is possible to provide a project name yourself. This makes finding the project in the Quantum Inspire web-interface
-easier.
+As a default, SDK stores the jobs in a Quantum Inspire project with the name "qi-sdk-project-" concatenated with a
+unique identifier for each run. Providing a project name yourself makes it easier to find the project in the Quantum
+Inspire web-interface and makes it possible to gather related jobs to the same project.
 
 Qiskit users do something like:
 ```python

--- a/docs/example_projectq_entangle.py
+++ b/docs/example_projectq_entangle.py
@@ -38,7 +38,7 @@ def get_authentication():
 
 if __name__ == '__main__':
 
-    project_name = 'TestProjectQ'
+    project_name = 'ProjectQ-entangle'
     authentication = get_authentication()
     qi_api = QuantumInspireAPI(QI_URL, authentication, project_name=project_name)
     qi_backend = QIBackend(quantum_inspire_api=qi_api)

--- a/docs/example_projectq_entangle.py
+++ b/docs/example_projectq_entangle.py
@@ -38,9 +38,9 @@ def get_authentication():
 
 if __name__ == '__main__':
 
-    name = 'TestProjectQ'
+    project_name = 'TestProjectQ'
     authentication = get_authentication()
-    qi_api = QuantumInspireAPI(QI_URL, authentication, project_name=name)
+    qi_api = QuantumInspireAPI(QI_URL, authentication, project_name=project_name)
     qi_backend = QIBackend(quantum_inspire_api=qi_api)
 
     compiler_engines = restrictedgateset.get_engine_list(one_qubit_gates=qi_backend.one_qubit_gates,

--- a/docs/example_qiskit_entangle.py
+++ b/docs/example_qiskit_entangle.py
@@ -45,8 +45,9 @@ def get_authentication():
 
 if __name__ == '__main__':
 
+    project_name = 'TestQiskit'
     authentication = get_authentication()
-    QI.set_authentication(authentication, QI_URL)
+    QI.set_authentication(authentication, QI_URL, project_name=project_name)
     qi_backend = QI.get_backend('QX single-node simulator')
 
     q = QuantumRegister(2)

--- a/docs/example_qiskit_entangle.py
+++ b/docs/example_qiskit_entangle.py
@@ -45,7 +45,7 @@ def get_authentication():
 
 if __name__ == '__main__':
 
-    project_name = 'TestQiskit'
+    project_name = 'Qiskit-entangle'
     authentication = get_authentication()
     QI.set_authentication(authentication, QI_URL, project_name=project_name)
     qi_backend = QI.get_backend('QX single-node simulator')

--- a/src/quantuminspire/api.py
+++ b/src/quantuminspire/api.py
@@ -251,12 +251,11 @@ class QuantumInspireAPI:
         """
         if identifier is None:
             return self.get_default_backend_type()
-        elif isinstance(identifier, int):
+        if isinstance(identifier, int):
             return self.get_backend_type_by_id(identifier)
-        elif isinstance(identifier, str):
+        if isinstance(identifier, str):
             return self.get_backend_type_by_name(identifier)
-        else:
-            raise ValueError('Identifier should be of type int, str or None!')
+        raise ValueError('Identifier should be of type int, str or None!')
 
     #  projects  #
 

--- a/src/quantuminspire/credentials.py
+++ b/src/quantuminspire/credentials.py
@@ -54,7 +54,7 @@ def read_account(filename: str = DEFAULT_QIRC_FILE) -> Optional[str]:
                   in the user home directory is used (`HOME/.quantuminspire/qirc`).
 
     Returns:
-        The Quantum Inspire token or None when no token is found.
+        The Quantum Inspire token or None when no token is found or token is empty.
     """
     try:
         with open(filename, 'r') as file:
@@ -62,7 +62,7 @@ def read_account(filename: str = DEFAULT_QIRC_FILE) -> Optional[str]:
             token: Optional[str] = accounts['token']
     except (OSError, KeyError, ValueError):  # file does not exist or is empty/invalid
         token = None
-    return token if (token and len(token)) else None
+    return token if token else None
 
 
 def store_account(token: str, filename: str = DEFAULT_QIRC_FILE, overwrite: bool = False) -> None:

--- a/src/quantuminspire/projectq/backend_qx.py
+++ b/src/quantuminspire/projectq/backend_qx.py
@@ -58,7 +58,7 @@ class QIBackend(BasicEngine):  # type: ignore
         """ Because engines are meant to be 'single use' by the way ProjectQ is designed,
         any additional gates received after a FlushGate triggers an exception. """
         self._clear: bool = True
-        self.qasm: str = ""
+        self._qasm: str = ""
         self._reset()
         self._verbose: int = verbose
         self._cqasm: str = str()
@@ -145,6 +145,11 @@ class QIBackend(BasicEngine):  # type: ignore
         """ Return cqasm code that is generated last. """
         return self._cqasm
 
+    @property
+    def qasm(self) -> str:
+        """ Return qasm code at any moment in the process. """
+        return self._qasm
+
     def is_available(self, cmd: Command) -> bool:
         """
         Via this method the ProjectQ framework determines which commands (gates) are available in the backend.
@@ -190,7 +195,7 @@ class QIBackend(BasicEngine):  # type: ignore
         """ Reset temporary variable qasm to an initial value and set a flag to clear variables in _store
             when _store is called. """
         self._clear = True
-        self.qasm = ""
+        self._qasm = ""
 
     def _allocate_qubit(self, index_to_add: int) -> None:
         """ On a simulation backend it is possible to reuse qubits. The advantage of reusing qubits is that less
@@ -262,8 +267,8 @@ class QIBackend(BasicEngine):  # type: ignore
 
                     # to reuse a de-allocated bit we do a prep_z first, which is better implemented as a
                     # measurement and binary controlled x-gate
-                    self.qasm += f"\nmeasure q[{allocation_entry[0]}]"
-                    self.qasm += f"\nc-x b[{allocation_entry[0]}], q[{allocation_entry[0]}]"
+                    self._qasm += f"\nmeasure q[{allocation_entry[0]}]"
+                    self._qasm += f"\nc-x b[{allocation_entry[0]}], q[{allocation_entry[0]}]"
                     index = self._allocation_map.index(allocation_entry)
                     self._allocation_map[index] = (allocation_entry[0], index_to_add)
 
@@ -311,8 +316,8 @@ class QIBackend(BasicEngine):  # type: ignore
                 raise RuntimeError(f"Bit position in simulation backend not found for"
                                    f" physical bit {physical_qubit_id}.")
             return allocation_entry[0]
-        else:
-            return physical_qubit_id
+
+        return physical_qubit_id
 
     def _switch_fsp_to_nonfsp(self) -> None:
         """ We have determined that the algorithm is non-deterministic and cannot use fsp.
@@ -322,7 +327,7 @@ class QIBackend(BasicEngine):  # type: ignore
         for logical_qubit_id in self._measured_ids:
             physical_qubit_id = self._logical_to_physical(logical_qubit_id)
             sim_qubit_id = self._physical_to_simulated(physical_qubit_id)
-            self.qasm += f"\nmeasure q[{sim_qubit_id}]"
+            self._qasm += f"\nmeasure q[{sim_qubit_id}]"
         self._full_state_projection = False
 
     def _store(self, cmd: Command) -> None:
@@ -339,7 +344,7 @@ class QIBackend(BasicEngine):  # type: ignore
 
         if self._clear:
             self._clear = False
-            self.qasm = ""
+            self._qasm = ""
             self._measured_states = {}
             self._measured_ids = []
             self._full_state_projection = not self._backend_type["is_hardware_backend"]
@@ -374,7 +379,7 @@ class QIBackend(BasicEngine):  # type: ignore
             # do not add the measurement statement when fsp is possible
             if not self._full_state_projection:
                 if self._is_simulation_backend:
-                    self.qasm += f"\nmeasure q[{sim_qubit_id}]"
+                    self._qasm += f"\nmeasure q[{sim_qubit_id}]"
             return
 
         # when we find a gate after measurements we don't have fsp
@@ -386,47 +391,47 @@ class QIBackend(BasicEngine):  # type: ignore
             # this case also covers the CX controlled gate
             ctrl_pos = self._physical_to_simulated(cmd.control_qubits[0].id)
             qb_pos = self._physical_to_simulated(cmd.qubits[0][0].id)
-            self.qasm += f"\ncnot q[{ctrl_pos}], q[{qb_pos}]"
+            self._qasm += f"\ncnot q[{ctrl_pos}], q[{qb_pos}]"
         elif gate == Swap:
             q0 = self._physical_to_simulated(cmd.qubits[0][0].id)
             q1 = self._physical_to_simulated(cmd.qubits[1][0].id)
-            self.qasm += f"\nswap q[{q0}], q[{q1}]"
+            self._qasm += f"\nswap q[{q0}], q[{q1}]"
         elif gate == X and get_control_count(cmd) == 2:
             ctrl_pos1 = self._physical_to_simulated(cmd.control_qubits[0].id)
             ctrl_pos2 = self._physical_to_simulated(cmd.control_qubits[1].id)
             qb_pos = self._physical_to_simulated(cmd.qubits[0][0].id)
-            self.qasm += f"\ntoffoli q[{ctrl_pos1}], q[{ctrl_pos2}], q[{qb_pos}]"
+            self._qasm += f"\ntoffoli q[{ctrl_pos1}], q[{ctrl_pos2}], q[{qb_pos}]"
         elif gate == Z and get_control_count(cmd) == 1:
             ctrl_pos = self._physical_to_simulated(cmd.control_qubits[0].id)
             qb_pos = self._physical_to_simulated(cmd.qubits[0][0].id)
-            self.qasm += f"\ncz q[{ctrl_pos}], q[{qb_pos}]"
+            self._qasm += f"\ncz q[{ctrl_pos}], q[{qb_pos}]"
         elif gate == Barrier:
             qb_pos_list = [qb.id for qr in cmd.qubits for qb in qr]
             qb_str = ', '.join([f'q[{self._physical_to_simulated(x)}]' for x in qb_pos_list])
-            self.qasm += f"\n# barrier gate {qb_str};"
+            self._qasm += f"\n# barrier gate {qb_str};"
         elif isinstance(gate, (Rz, R)) and get_control_count(cmd) == 1:
             ctrl_pos = self._physical_to_simulated(cmd.control_qubits[0].id)
             qb_pos = self._physical_to_simulated(cmd.qubits[0][0].id)
             gate_name = 'cr'
-            self.qasm += f"\n{gate_name} q[{ctrl_pos}],q[{qb_pos}],{gate.angle:.12f}"
+            self._qasm += f"\n{gate_name} q[{ctrl_pos}],q[{qb_pos}],{gate.angle:.12f}"
         elif isinstance(gate, (Rx, Ry)) and get_control_count(cmd) == 1:
             raise NotImplementedError('controlled Rx or Ry gate not implemented')
         elif isinstance(gate, (Rx, Ry, Rz)):
             assert get_control_count(cmd) == 0
             qb_pos = self._physical_to_simulated(cmd.qubits[0][0].id)
             gate_name = str(gate)[0:2].lower()
-            self.qasm += f"\n{gate_name} q[{qb_pos}],{gate.angle:.12g}"
+            self._qasm += f"\n{gate_name} q[{qb_pos}],{gate.angle:.12g}"
         elif gate == Tdag and get_control_count(cmd) == 0:
             qb_pos = self._physical_to_simulated(cmd.qubits[0][0].id)
-            self.qasm += f"\ntdag q[{qb_pos}]"
+            self._qasm += f"\ntdag q[{qb_pos}]"
         elif gate == Sdag and get_control_count(cmd) == 0:
             qb_pos = self._physical_to_simulated(cmd.qubits[0][0].id)
-            self.qasm += f"\nsdag q[{qb_pos}]"
+            self._qasm += f"\nsdag q[{qb_pos}]"
         elif isinstance(gate, tuple(type(gate) for gate in (X, Y, Z, H, S, T))):
             assert get_control_count(cmd) == 0
             gate_str = str(gate).lower()
             qb_pos = self._physical_to_simulated(cmd.qubits[0][0].id)
-            self.qasm += f"\n{gate_str} q[{qb_pos}]"
+            self._qasm += f"\n{gate_str} q[{qb_pos}]"
         else:
             raise NotImplementedError(f'cmd {(cmd,)} not implemented')
 
@@ -448,8 +453,8 @@ class QIBackend(BasicEngine):  # type: ignore
                                    f"was eliminated during optimization.")
 
             return int(mapping[logical_qubit_id])
-        else:
-            return logical_qubit_id  # no mapping
+
+        return logical_qubit_id  # no mapping
 
     def get_probabilities(self, qureg: List[Qubit]) -> Dict[str, float]:
         """
@@ -519,7 +524,7 @@ class QIBackend(BasicEngine):  # type: ignore
 
         Send the circuit via the Quantum Inspire API.
         """
-        if self.qasm == "":
+        if self._qasm == "":
             return
 
         # Finally: add measurement commands for all measured qubits if no measurements are given.
@@ -537,7 +542,7 @@ class QIBackend(BasicEngine):  # type: ignore
         """ Finalize qasm (add version and qubits line). """
         qasm = f'version 1.0\n# cQASM generated by Quantum Inspire {self.__class__} class\n' \
                f'qubits {self._number_of_qubits}\n'
-        qasm += self.qasm
+        qasm += self._qasm
 
         if self._verbose >= 2:
             print(qasm)
@@ -630,8 +635,8 @@ class QIBackend(BasicEngine):  # type: ignore
         """ Return the number of qubits used in the circuit. If it is a hardware backend return max nr of qubits """
         if self._is_simulation_backend:
             return self._max_qubit_id + 1
-        else:
-            return self._max_number_of_qubits
+
+        return self._max_number_of_qubits
 
     def receive(self, command_list: List[Command]) -> None:
         """

--- a/src/quantuminspire/projectq/backend_qx.py
+++ b/src/quantuminspire/projectq/backend_qx.py
@@ -39,9 +39,7 @@ CR = C(R)
 
 
 class QIBackend(BasicEngine):  # type: ignore
-    """ Backend for Quantum Inspire
-
-    """
+    """ Backend for Quantum Inspire """
 
     def __init__(self, num_runs: int = 1024, verbose: int = 0, quantum_inspire_api: Optional[QuantumInspireAPI] = None,
                  backend_type: Optional[Union[int, str]] = None) -> None:
@@ -60,6 +58,7 @@ class QIBackend(BasicEngine):  # type: ignore
         """ Because engines are meant to be 'single use' by the way ProjectQ is designed,
         any additional gates received after a FlushGate triggers an exception. """
         self._clear: bool = True
+        self.qasm: str = ""
         self._reset()
         self._verbose: int = verbose
         self._cqasm: str = str()
@@ -67,6 +66,7 @@ class QIBackend(BasicEngine):  # type: ignore
         self._measured_ids: List[int] = []
         self._allocation_map: List[Tuple[int, int]] = []
         self._max_qubit_id: int = -1
+        self._quantum_inspire_result: Dict[str, Any] = {}
         if quantum_inspire_api is None:
             try:
                 quantum_inspire_api = QuantumInspireAPI()
@@ -286,10 +286,10 @@ class QIBackend(BasicEngine):  # type: ignore
             allocation_entry = next(iter(x for x in self._allocation_map if x[1] == index_to_remove), None)
             if allocation_entry is None:
                 raise RuntimeError(f"De-allocated bit {index_to_remove} was not allocated.")
-            else:
-                # deallocate the corresponding simulation bit
-                index = self._allocation_map.index(allocation_entry)
-                self._allocation_map[index] = (allocation_entry[0], -1)
+
+            # deallocate the corresponding simulation bit
+            index = self._allocation_map.index(allocation_entry)
+            self._allocation_map[index] = (allocation_entry[0], -1)
 
         if self._verbose >= 1:
             print(f'_store: Deallocate gate {(index_to_remove,)}')
@@ -310,8 +310,7 @@ class QIBackend(BasicEngine):  # type: ignore
             if allocation_entry is None:
                 raise RuntimeError(f"Bit position in simulation backend not found for"
                                    f" physical bit {physical_qubit_id}.")
-            else:
-                return allocation_entry[0]
+            return allocation_entry[0]
         else:
             return physical_qubit_id
 

--- a/src/quantuminspire/qiskit/circuit_parser.py
+++ b/src/quantuminspire/qiskit/circuit_parser.py
@@ -16,9 +16,11 @@ limitations under the License.
 
 """
 import copy
-import numpy as np
 from io import StringIO
 from typing import Optional, Tuple, List
+
+import numpy as np
+
 from qiskit.qobj import QasmQobjInstruction
 from quantuminspire.exceptions import ApiError
 
@@ -44,8 +46,8 @@ class CircuitToString:
         """
         if hasattr(instruction, 'conditional'):
             raise ApiError(f'Conditional gate c-{instruction.name.lower()} not supported')
-        else:
-            raise ApiError(f'Gate {instruction.name.lower()} not supported')
+
+        raise ApiError(f'Gate {instruction.name.lower()} not supported')
 
     @staticmethod
     def _cz(stream: StringIO, instruction: QasmQobjInstruction) -> None:
@@ -569,7 +571,6 @@ class CircuitToString:
             instruction: The Qiskit instruction to translate to cQASM.
 
         """
-        pass
 
     @staticmethod
     def _c_barrier(stream: StringIO, instruction: QasmQobjInstruction, binary_control: str) -> None:
@@ -581,7 +582,6 @@ class CircuitToString:
             binary_control: The multi-bits control string. The gate is executed when all specified classical bits are 1.
 
         """
-        pass
 
     def _measure(self, stream: StringIO, instruction: QasmQobjInstruction) -> None:
         """ Translates the measure element. No cQASM is added for this gate when FSP is used.

--- a/src/quantuminspire/qiskit/qi_job.py
+++ b/src/quantuminspire/qiskit/qi_job.py
@@ -84,7 +84,7 @@ class QIJob(BaseJob):  # type: ignore
             timeout: Timeout in seconds.
             wait: Wait time between queries to the quantum-inspire platform.
             only_latest_run: when True, only the result for the experiments in the latest run for this project are
-            fetched, when False all the results for the project are fetched
+            fetched, when False all the experiment results for all the jobs in the project are fetched
 
         Returns:
             QIResult object containing results from the experiments.
@@ -99,7 +99,10 @@ class QIJob(BaseJob):  # type: ignore
             if timeout is not None and elapsed_time > timeout:
                 raise JobTimeoutError('Failed getting result: timeout reached.')
             time.sleep(wait)
-        experiment_results = self._backend.get_experiment_results(self, only_latest_run)
+        if only_latest_run:
+            experiment_results = self._backend.get_experiment_results_from_latest_run(self)
+        else:
+            experiment_results = self._backend.get_experiment_results_from_all_jobs(self)
         return QIResult(backend_name=self._backend.backend_name, backend_version=quantum_inspire_version,
                         job_id=self.job_id(), qobj_id=self.job_id(), success=True, results=experiment_results)
 

--- a/src/quantuminspire/qiskit/qi_job.py
+++ b/src/quantuminspire/qiskit/qi_job.py
@@ -77,7 +77,7 @@ class QIJob(BaseJob):  # type: ignore
             raise JobError('Job has already been submitted!')
         self._job_id = self._backend.run(self._qobj)
 
-    def result(self, timeout: Optional[float] = None, wait: float = 0.5, only_latest_run: bool = False) -> QIResult:
+    def result(self, timeout: Optional[float] = None, wait: float = 0.5, only_latest_run: bool = True) -> QIResult:
         """
 
         Args:

--- a/src/quantuminspire/qiskit/qi_result.py
+++ b/src/quantuminspire/qiskit/qi_result.py
@@ -87,5 +87,5 @@ class QIResult(Result):  # type: ignore
         # Return first item of dict_list if size is 1
         if len(dict_list) == 1:
             return dict_list[0]
-        else:
-            return dict_list
+
+        return dict_list

--- a/src/quantuminspire/qiskit/quantum_inspire_provider.py
+++ b/src/quantuminspire/qiskit/quantum_inspire_provider.py
@@ -146,7 +146,7 @@ class QuantumInspireProvider(BaseProvider):  # type: ignore
         self.set_authentication(authentication, qi_url)
 
     def set_authentication(self, authentication: Optional[coreapi.auth.AuthBase] = None,
-                           qi_url: str = QI_URL) -> None:
+                           qi_url: str = QI_URL, project_name: Optional[str] = None) -> None:
         """
         Initializes the API and sets the authentication for Quantum Inspire.
 
@@ -156,5 +156,17 @@ class QuantumInspireProvider(BaseProvider):  # type: ignore
                             TokenAuthentication(token, scheme="token"), token authentication with a valid API-token.
                             When authentication is None, api will try to load a token from the default resource.
             qi_url: URL that points to quantum-inspire api. Default value: 'https://api.quantum-inspire.com'.
+            project_name: The project name of the project that is used for executing the jobs.
         """
-        self._api = QuantumInspireAPI(qi_url, authentication)
+        self._api = QuantumInspireAPI(qi_url, authentication, project_name)
+
+    def set_project_name(self, project_name: str) -> None:
+        """
+        Set the project name for the Quantum Inspire project that is used for executing the jobs.
+        Default a generated project-name is used, but it can be overridden by the user.
+
+        Args:
+            project_name: project name of the QI project used for executing the jobs.
+        """
+        if self._api is not None:
+            self._api.project_name = project_name

--- a/src/tests/quantuminspire/projectq/test_backend_qx.py
+++ b/src/tests/quantuminspire/projectq/test_backend_qx.py
@@ -121,6 +121,14 @@ class QIBackendNonProtected(QIBackend):
         self._measured_ids = x
 
     @property
+    def qasm(self):
+        return self._qasm
+
+    @qasm.setter
+    def qasm(self, x):
+        self._qasm = x
+
+    @property
     def number_of_qubits(self):
         return self._number_of_qubits
 

--- a/src/tests/quantuminspire/qiskit/test_backend_qx.py
+++ b/src/tests/quantuminspire/qiskit/test_backend_qx.py
@@ -165,7 +165,7 @@ class TestQiSimulatorPy(unittest.TestCase):
         job.job_id.return_value = '42'
         simulator = QuantumInspireBackend(api, Mock())
         with self.assertRaises(QisKitBackendError) as error:
-            simulator.get_experiment_results(job, False)
+            simulator.get_experiment_results_from_all_jobs(job)
         self.assertEqual(('Result from backend contains no histogram data!\nError',), error.exception.args)
 
     def test_get_experiment_results_returns_correct_value_from_project(self):
@@ -188,7 +188,7 @@ class TestQiSimulatorPy(unittest.TestCase):
         api.get_jobs_from_project.return_value = [jobs]
         job = QIJob('backend', '42', api)
         simulator = QuantumInspireBackend(api, Mock())
-        experiment_result = simulator.get_experiment_results(job, False)[0]
+        experiment_result = simulator.get_experiment_results_from_all_jobs(job)[0]
         self.assertEqual(experiment_result.data.counts['0x1'], 60)
         self.assertEqual(experiment_result.data.counts['0x3'], 40)
         self.assertEqual(experiment_result.data.probabilities['0x1'], 0.6)
@@ -224,7 +224,7 @@ class TestQiSimulatorPy(unittest.TestCase):
         qijob.add_job(quantuminspire_job)
 
         simulator = QuantumInspireBackend(api, Mock())
-        experiment_result = simulator.get_experiment_results(qijob, True)[0]
+        experiment_result = simulator.get_experiment_results_from_latest_run(qijob)[0]
         self.assertEqual(experiment_result.data.counts['0x1'], 60)
         self.assertEqual(experiment_result.data.counts['0x3'], 40)
         self.assertEqual(experiment_result.data.probabilities['0x1'], 0.6)
@@ -282,7 +282,7 @@ class TestQiSimulatorPy(unittest.TestCase):
         api.get_jobs_from_project.return_value = [jobs]
         job = QIJob('backend', '42', api)
         simulator = QuantumInspireBackend(api, Mock())
-        experiment_result = simulator.get_experiment_results(job, False)[0]
+        experiment_result = simulator.get_experiment_results_from_all_jobs(job)[0]
         self.assertEqual(experiment_result.data.probabilities['0x0'], 0.5)
         self.assertEqual(experiment_result.data.probabilities['0x3'], 0.5)
         self.assertTrue(hasattr(experiment_result.data, 'memory'))
@@ -322,7 +322,7 @@ class TestQiSimulatorPy(unittest.TestCase):
             api.get_jobs_from_project.return_value = [jobs]
             job = QIJob('backend', '42', api)
             simulator = QuantumInspireBackend(api, Mock())
-            experiment_result = simulator.get_experiment_results(job, False)[0]
+            experiment_result = simulator.get_experiment_results_from_all_jobs(job)[0]
             # Exactly one value in memory
             self.assertEqual(len(experiment_result.data.memory), 1)
             # The only value in memory is the same as the value in the counts histogram.
@@ -596,7 +596,7 @@ class TestQiSimulatorPyHistogram(unittest.TestCase):
         self.mock_api.get_jobs_from_project.return_value = [jobs]
         job = QIJob('backend', '42', self.mock_api)
 
-        result = self.simulator.get_experiment_results(job, False)
+        result = self.simulator.get_experiment_results_from_all_jobs(job)
         number_of_shots = jobs['number_of_shots']
         self.assertEqual(1, len(result))
         first_experiment = first_item(result)

--- a/src/tests/quantuminspire/qiskit/test_qi_job.py
+++ b/src/tests/quantuminspire/qiskit/test_qi_job.py
@@ -121,7 +121,7 @@ class TestQIJob(unittest.TestCase):
         backend.get_experiment_results_from_all_jobs.return_value = [self.experiment_result_1, self.experiment_result_2]
         backend.backend_name = 'some backend'
         job = QIJob(backend, job_id, api)
-        results = job.result(only_latest_run=False)
+        results = job.result_all_jobs()
 
         self.assertTrue(results.success)
         self.assertDictEqual({'counts': {'0x0': 42}}, results.data(0))

--- a/src/tests/quantuminspire/qiskit/test_qi_job.py
+++ b/src/tests/quantuminspire/qiskit/test_qi_job.py
@@ -113,17 +113,18 @@ class TestQIJob(unittest.TestCase):
 
     def test_result_timeout(self):
         api = Mock()
-        api.get_jobs_from_project.return_value = [{'name': 'test_job', 'status': 'COMPLETE'},
-                                                  {'name': 'other_job', 'status': 'RUNNING'}]
+        api.get_job.return_value = {'name': 'other_job', 'status': 'RUNNING'}
         job_id = '42'
         backend = Mock()
-        job = QIJob(backend, job_id, api)
+        quantuminspire_job = Mock()
+        quantuminspire_job.get_job_identifier.return_value = [1]
+        qijob = QIJob(backend, job_id, api)
+        qijob.add_job(quantuminspire_job)
         with self.assertRaises(JobTimeoutError):
-            job.result(timeout=1e-2, wait=0)
+            qijob.result(timeout=1e-2, wait=0)
 
     def test_result_cancelled(self):
         api = Mock()
-        api.get_jobs_from_project.return_value = [{'name': 'Test3', 'status': 'CANCELLED'}]
         job_id = '42'
         backend = Mock()
         backend.get_experiment_results.return_value = [self.experiment_result_3]
@@ -145,40 +146,50 @@ class TestQIJob(unittest.TestCase):
 
     def test_status(self):
         api = Mock()
-        api.get_jobs_from_project.return_value = [{'name': 'test_job', 'status': 'COMPLETE'},
-                                                  {'name': 'other_job', 'status': 'RUNNING'}]
+        api.get_job.side_effect = [{'name': 'test_job', 'status': 'COMPLETE'},
+                                   {'name': 'other_job', 'status': 'RUNNING'}]
         job_id = '42'
         backend = Mock()
-        job = QIJob(backend, job_id, api)
-        status = job.status()
+        quantuminspire_job = Mock()
+        quantuminspire_job.get_job_identifier.side_effect = [1, 2]
+        qijob = QIJob(backend, job_id, api)
+        qijob.add_job(quantuminspire_job)
+        qijob.add_job(quantuminspire_job)
+        status = qijob.status()
         self.assertEqual(JobStatus.RUNNING, status)
 
-        api.get_jobs_from_project.return_value = [{'name': 'test_job', 'status': 'COMPLETE'},
-                                                  {'name': 'other_job', 'status': 'COMPLETE'}]
-        status = job.status()
+        api.get_job.side_effect = [{'name': 'test_job', 'status': 'COMPLETE'},
+                                   {'name': 'other_job', 'status': 'COMPLETE'}]
+        quantuminspire_job.get_job_identifier.side_effect = [1, 2]
+        status = qijob.status()
         self.assertEqual(JobStatus.DONE, status)
 
-        api.get_jobs_from_project.return_value = [{'name': 'test_job', 'status': 'CANCELLED'},
-                                                  {'name': 'other_job', 'status': 'COMPLETE'}]
-        status = job.status()
+        api.get_job.side_effect = [{'name': 'test_job', 'status': 'CANCELLED'},
+                                   {'name': 'other_job', 'status': 'COMPLETE'}]
+        quantuminspire_job.get_job_identifier.side_effect = [1, 2]
+        status = qijob.status()
         self.assertEqual(JobStatus.ERROR, status)
 
-        api.get_jobs_from_project.return_value = [{'name': 'test_job', 'status': 'NEW'},
-                                                  {'name': 'other_job', 'status': 'NEW'}]
-        status = job.status()
+        api.get_job.side_effect = [{'name': 'test_job', 'status': 'NEW'},
+                                   {'name': 'other_job', 'status': 'NEW'}]
+        quantuminspire_job.get_job_identifier.side_effect = [1, 2]
+        status = qijob.status()
         self.assertEqual(JobStatus.QUEUED, status)
 
-        api.get_jobs_from_project.return_value = [{'name': 'test_job', 'status': 'CANCELLED'},
-                                                  {'name': 'other_job', 'status': 'CANCELLED'}]
-        status = job.status()
+        api.get_job.side_effect = [{'name': 'test_job', 'status': 'CANCELLED'},
+                                   {'name': 'other_job', 'status': 'CANCELLED'}]
+        quantuminspire_job.get_job_identifier.side_effect = [1, 2]
+        status = qijob.status()
         self.assertEqual(JobStatus.CANCELLED, status)
 
-        api.get_jobs_from_project.return_value = [{'name': 'test_job', 'status': 'NEW'},
-                                                  {'name': 'other_job', 'status': 'RUNNING'}]
-        status = job.status()
+        api.get_job.side_effect = [{'name': 'test_job', 'status': 'NEW'},
+                                   {'name': 'other_job', 'status': 'RUNNING'}]
+        quantuminspire_job.get_job_identifier.side_effect = [1, 2]
+        status = qijob.status()
         self.assertEqual(JobStatus.RUNNING, status)
 
-        api.get_jobs_from_project.return_value = [{'name': 'test_job', 'status': 'NEW'},
-                                                  {'name': 'other_job', 'status': 'COMPLETE'}]
-        status = job.status()
+        api.get_job.side_effect = [{'name': 'test_job', 'status': 'NEW'},
+                                   {'name': 'other_job', 'status': 'COMPLETE'}]
+        quantuminspire_job.get_job_identifier.side_effect = [1, 2]
+        status = qijob.status()
         self.assertEqual(JobStatus.RUNNING, status)

--- a/src/tests/quantuminspire/qiskit/test_quantum_inspire_provider.py
+++ b/src/tests/quantuminspire/qiskit/test_quantum_inspire_provider.py
@@ -73,7 +73,7 @@ class TestQuantumInspireProvider(unittest.TestCase):
             secret = 'secret'
             quantum_inpire_provider.set_basic_authentication(email, secret)
             authentication = BasicAuthentication(email, secret)
-            api.assert_called_with(QI_URL, authentication)
+            api.assert_called_with(QI_URL, authentication, None)
             quantum_inpire_provider._api.get_backend_types.return_value = [self.simulator_backend_type]
             backend = quantum_inpire_provider.get_backend(name='qi_simulator')
             self.assertEqual('qi_simulator', backend.name())
@@ -90,7 +90,7 @@ class TestQuantumInspireProvider(unittest.TestCase):
             secret = 'secret'
             quantum_inpire_provider.set_basic_authentication(email, secret)
             authentication = BasicAuthentication(email, secret)
-            api.assert_called_with(QI_URL, authentication)
+            api.assert_called_with(QI_URL, authentication, None)
             quantum_inpire_provider._api.get_backend_types.return_value = [self.simulator_backend_type]
             backend = quantum_inpire_provider.get_backend(name='qi_simulator')
             self.assertEqual('qi_simulator', backend.name())
@@ -114,7 +114,7 @@ class TestQuantumInspireProvider(unittest.TestCase):
             secret = 'secret'
             quantum_inpire_provider.set_basic_authentication(email, secret)
             authentication = BasicAuthentication(email, secret)
-            api.assert_called_with(QI_URL, authentication)
+            api.assert_called_with(QI_URL, authentication, None)
             quantum_inpire_provider._api.get_backend_types.return_value = [self.hardware_backend_type]
             backend = quantum_inpire_provider.get_backend(name='qi_hardware')
             self.assertEqual('qi_hardware', backend.name())
@@ -137,7 +137,7 @@ class TestQuantumInspireProvider(unittest.TestCase):
             secret = 'secret'
             quantum_inpire_provider.set_basic_authentication(email, secret)
             authentication = BasicAuthentication(email, secret)
-            api.assert_called_with(QI_URL, authentication)
+            api.assert_called_with(QI_URL, authentication, None)
             quantum_inpire_provider._api.get_backend_types.return_value = [self.hardware_backend_type2]
             backend = quantum_inpire_provider.get_backend(name='qi_hardware')
             self.assertEqual('qi_hardware', backend.name())
@@ -161,7 +161,7 @@ class TestQuantumInspireProvider(unittest.TestCase):
             secret = 'secret'
             quantum_inpire_provider.set_authentication_details(email, secret)
             authentication = BasicAuthentication(email, secret)
-            api.assert_called_with(QI_URL, authentication)
+            api.assert_called_with(QI_URL, authentication, None)
             quantum_inpire_provider._api.get_backend_types.return_value = [self.simulator_backend_type]
             backend = quantum_inpire_provider.get_backend(name='qi_simulator')
             self.assertEqual('qi_simulator', backend.name())
@@ -175,7 +175,7 @@ class TestQuantumInspireProvider(unittest.TestCase):
             secret = 'secret'
             quantum_inpire_provider.set_basic_authentication(email, secret)
             authentication = BasicAuthentication(email, secret)
-            api.assert_called_with(QI_URL, authentication)
+            api.assert_called_with(QI_URL, authentication, None)
             quantum_inpire_provider._api.get_backend_types.return_value = [self.simulator_backend_type]
             backend = quantum_inpire_provider.get_backend(name='qi_simulator')
             self.assertEqual('qi_simulator', backend.name())
@@ -191,7 +191,7 @@ class TestQuantumInspireProvider(unittest.TestCase):
             url = 'https/some-api.api'
             quantum_inpire_provider.set_basic_authentication(email, secret, url)
             authentication = BasicAuthentication(email, secret)
-            api.assert_called_with(url, authentication)
+            api.assert_called_with(url, authentication, None)
 
     def test_set_token_authentication(self):
         with mock.patch('quantuminspire.qiskit.quantum_inspire_provider.QuantumInspireAPI') as api:
@@ -210,10 +210,23 @@ class TestQuantumInspireProvider(unittest.TestCase):
             token = 'This_is_a_nice_looking_token'
             authentication = TokenAuthentication(token, scheme="token")
             quantum_inpire_provider.set_authentication(authentication)
-            api.assert_called_with(QI_URL, authentication)
+            api.assert_called_with(QI_URL, authentication, None)
             authentication = BasicAuthentication('email', 'password')
             quantum_inpire_provider.set_authentication(authentication)
-            api.assert_called_with(QI_URL, authentication)
+            api.assert_called_with(QI_URL, authentication, None)
+
+    def test_set_projectname(self):
+        with mock.patch('quantuminspire.qiskit.quantum_inspire_provider.QuantumInspireAPI') as api:
+            quantum_inpire_provider = QuantumInspireProvider()
+            token = 'This_is_a_nice_looking_token'
+            token = 'This_is_a_nice_looking_token'
+            authentication = TokenAuthentication(token, scheme="token")
+            project_name = 'This_is_my_first_project_name'
+            quantum_inpire_provider.set_authentication(authentication, project_name = project_name)
+            api.assert_called_with(QI_URL, authentication, project_name)
+            project_name = 'This_is_my_second_project_name'
+            quantum_inpire_provider.set_project_name(project_name)
+            self.assertEqual(api.return_value.project_name, project_name)
 
     def test_string_method(self):
         quantum_inpire_provider = QuantumInspireProvider()

--- a/src/tests/quantuminspire/qiskit/test_quantum_inspire_provider.py
+++ b/src/tests/quantuminspire/qiskit/test_quantum_inspire_provider.py
@@ -219,7 +219,6 @@ class TestQuantumInspireProvider(unittest.TestCase):
         with mock.patch('quantuminspire.qiskit.quantum_inspire_provider.QuantumInspireAPI') as api:
             quantum_inpire_provider = QuantumInspireProvider()
             token = 'This_is_a_nice_looking_token'
-            token = 'This_is_a_nice_looking_token'
             authentication = TokenAuthentication(token, scheme="token")
             project_name = 'This_is_my_first_project_name'
             quantum_inpire_provider.set_authentication(authentication, project_name = project_name)

--- a/version.py
+++ b/version.py
@@ -1,0 +1,5 @@
+if __name__ == '__main__':
+    version_namespace = {}
+    with open('src/quantuminspire/version.py', 'r') as f:
+        exec(f.read(), version_namespace)
+    print(version_namespace['__version__'])


### PR DESCRIPTION
* When using Qiskit, now also Quantum Inspire project names can be set
* When no project name is set, a default is taken
* When an existing project name is chosen, the experiments are added to the existing project
* qi_job.result() now has a parameter to only fetch the results for the latest run (instead ALL results for the project)