### PR TITLE
[SDS-301] Fix for damaged projects and not enough classical bits

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ build:
   image: latest
 
 python:
-  version: 3.9
+  version: 3.8
   setup_py_install: true
   pip_install: true
   extra_requirements:

--- a/docs/examples/example_projectq.ipynb
+++ b/docs/examples/example_projectq.ipynb
@@ -44,8 +44,8 @@
    "outputs": [],
    "source": [
     "authentication = get_authentication()\n",
-    "\n",
     "qi_api = QuantumInspireAPI(QI_URL, authentication)\n",
+    "\n",
     "projectq_backend = QIBackend(quantum_inspire_api=qi_api)"
    ]
   },
@@ -220,15 +220,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.4"
-  },
-  "pycharm": {
-   "stem_cell": {
-    "cell_type": "raw",
-    "metadata": {
-     "collapsed": false
-    },
-    "source": []
-   }
   }
  },
  "nbformat": 4,

--- a/docs/examples/grover_algorithm_qi.ipynb
+++ b/docs/examples/grover_algorithm_qi.ipynb
@@ -764,7 +764,6 @@
    "outputs": [],
    "source": [
     "authentication = get_authentication()\n",
-    "\n",
     "QI.set_authentication(authentication, QI_URL)"
    ]
   },

--- a/docs/examples/qi-performance-test.ipynb
+++ b/docs/examples/qi-performance-test.ipynb
@@ -39,37 +39,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def format_vector(state_vector, decimal_precision=7):\n",
-    "    \"\"\" Format the state vector into a LaTeX formatted string.\n",
-    "\n",
-    "    Args:\n",
-    "        state_vector (list or array): The state vector with complex\n",
-    "                                      values e.g. [-1, 2j+1].\n",
-    "\n",
-    "    Returns:\n",
-    "        str: The LaTeX format.\n",
-    "    \"\"\"\n",
-    "    result = []\n",
-    "    epsilon = 1/pow(10, decimal_precision)\n",
-    "    bit_length = (len(state_vector) - 1).bit_length()\n",
-    "    for index, complex_value in enumerate(state_vector):\n",
-    "        has_imag_part = np.round(complex_value.imag, decimal_precision) != 0.0\n",
-    "        value = complex_value if has_imag_part else complex_value.real\n",
-    "        value_round = np.round(value, decimal_precision)\n",
-    "        if np.abs(value_round) < epsilon:\n",
-    "            continue\n",
-    "\n",
-    "        binary_state = '{0:0{1}b}'.format(index, bit_length)\n",
-    "        result.append(r'{0:+2g}\\left\\lvert {1}\\right\\rangle '.format(value_round, binary_state))\n",
-    "    return ''.join(result)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -140,7 +109,6 @@
    "outputs": [],
    "source": [
     "authentication = get_authentication()\n",
-    "\n",
     "QI.set_authentication(authentication, QI_URL)"
    ]
   },

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -109,7 +109,7 @@ or when you want to choose which example notebook to run from the browser do:
 
     jupyter notebook --notebook-dir="docs/notebooks"
 
-and select an IPython notebook (file with extension ``ipynb``) to run.
+and select a Jupyter notebook (file with extension ``ipynb``) to run.
 
 To perform Grover's with the ProjectQ backend from a Python script:
 

--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -284,8 +284,8 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
         number_of_classical_bits = measurements['number_of_clbits']
         max_measurement_index = max(measurement[1] for measurement in measurements['measurements'])
         if max_measurement_index >= number_of_classical_bits:
-            raise QisKitBackendError("Number of classical bits is not sufficient for storing the outcomes of the"
-                                     " experiment")
+            raise QisKitBackendError(f"Number of classical bits ({number_of_classical_bits}) is not sufficient for "
+                                     f"storing the outcomes of the experiment")
 
         if BaseBackend.configuration(self).conditional:
             number_of_qubits = experiment.header.n_qubits
@@ -391,7 +391,7 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
         return classical_state_hex
 
     @staticmethod
-    def __convert_histogram(result: Dict[str, Any], measurements: Dict[str, Any])  -> Dict[str, float]:
+    def __convert_histogram(result: Dict[str, Any], measurements: Dict[str, Any]) -> Dict[str, float]:
         """Convert histogram
 
         The quantum inspire backend always uses full state projection. The SDK user
@@ -418,7 +418,6 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
         sorted_histogram_probabilities: List[Tuple[str, float]] = sorted(output_histogram_probabilities.items(),
                                                                          key=lambda kv: int(kv[0], 16))
         return dict(sorted_histogram_probabilities)
-
 
     def __convert_result_data(self, result: Dict[str, Any], measurements: Dict[str, Any]) -> Tuple[Dict[str, int],
                                                                                                    List[str]]:

--- a/src/tests/quantuminspire/qiskit/test_backend_qx.py
+++ b/src/tests/quantuminspire/qiskit/test_backend_qx.py
@@ -270,14 +270,7 @@ class TestQiSimulatorPy(unittest.TestCase):
         api.execute_qasm_async.return_value = quantum_inspire_job
         api.get_backend_type_by_name.return_value = {'max_number_of_shots': 4096}
         simulator = QuantumInspireBackend(api, Mock())
-        instructions = [{'name': 'h', 'qubits': [0]},
-                        {'name': 'h', 'qubits': [2]},
-                        {'memory': [0], 'name': 'measure', 'qubits': [1]},
-                        {'memory': [1], 'name': 'measure', 'qubits': [0]},
-                        {'mask': '0x2', 'name': 'bfunc', 'register': 7, 'relation': '==', 'val': '0x2'},
-                        {'conditional': 7, 'name': 'h', 'qubits': [1]},
-                        {'memory': [1], 'name': 'measure', 'qubits': [0]},
-                        {'memory': [0], 'name': 'measure', 'qubits': [1]}]
+        instructions = [{'memory': [0], 'name': 'measure', 'qubits': [1]}]
         qobj_dict = self._basic_qobj_dictionary
         qobj_dict['experiments'][0]['instructions'] = instructions
         qobj_dict['experiments'][0]['header']['memory_slots'] = 0
@@ -418,7 +411,7 @@ class TestQiSimulatorPy(unittest.TestCase):
         qobj_dict['experiments'][0]['instructions'] = instructions
         job_dict['experiments'][0]['header']['memory_slots'] = 1
         job = qiskit.qobj.QasmQobj.from_dict(job_dict)
-        self.assertRaisesRegex(QisKitBackendError, 'Number of classical bits is not sufficient for storing the '
+        self.assertRaisesRegex(QisKitBackendError, 'Number of classical bits \(1\) is not sufficient for storing the '
                                                    'outcomes of the experiment',
                                simulator.run, job)
 

--- a/src/tests/quantuminspire/qiskit/test_backend_qx.py
+++ b/src/tests/quantuminspire/qiskit/test_backend_qx.py
@@ -29,7 +29,7 @@ from qiskit.providers.models.backendconfiguration import GateConfig
 from qiskit.qobj import QasmQobjExperiment, QasmQobj
 
 from quantuminspire.api import QuantumInspireAPI
-from quantuminspire.exceptions import QisKitBackendError
+from quantuminspire.exceptions import QisKitBackendError, ApiError
 from quantuminspire.qiskit.backend_qx import QuantumInspireBackend
 from quantuminspire.qiskit.qi_job import QIJob
 from quantuminspire.job import QuantumInspireJob
@@ -260,6 +260,32 @@ class TestQiSimulatorPy(unittest.TestCase):
         api.delete_project.assert_called_with(default_project_number)
         self.assertEqual(my_project_number, int(job.job_id()))
 
+    def test_run_deletes_empty_project_when_error_occurs(self):
+        default_project_number = 42
+        my_project_number = 43
+        api = Mock()
+        api.create_project.return_value = {'id': default_project_number}
+        quantum_inspire_job = Mock()
+        quantum_inspire_job.get_project_identifier.return_value = my_project_number
+        api.execute_qasm_async.return_value = quantum_inspire_job
+        api.get_backend_type_by_name.return_value = {'max_number_of_shots': 4096}
+        simulator = QuantumInspireBackend(api, Mock())
+        instructions = [{'name': 'h', 'qubits': [0]},
+                        {'name': 'h', 'qubits': [2]},
+                        {'memory': [0], 'name': 'measure', 'qubits': [1]},
+                        {'memory': [1], 'name': 'measure', 'qubits': [0]},
+                        {'mask': '0x2', 'name': 'bfunc', 'register': 7, 'relation': '==', 'val': '0x2'},
+                        {'conditional': 7, 'name': 'h', 'qubits': [1]},
+                        {'memory': [1], 'name': 'measure', 'qubits': [0]},
+                        {'memory': [0], 'name': 'measure', 'qubits': [1]}]
+        qobj_dict = self._basic_qobj_dictionary
+        qobj_dict['experiments'][0]['instructions'] = instructions
+        qobj_dict['experiments'][0]['header']['memory_slots'] = 0
+        qobj = QasmQobj.from_dict(qobj_dict)
+        self.assertRaisesRegex(QisKitBackendError, 'Invalid amount of classical bits \(0\)!',
+                               simulator.run, qobj)
+        api.delete_project.assert_called_with(default_project_number)
+
     def test_get_experiment_results_returns_single_shot(self):
         number_of_shots = 1
         self._basic_job_dictionary['number_of_shots'] = number_of_shots
@@ -378,6 +404,22 @@ class TestQiSimulatorPy(unittest.TestCase):
         job = qiskit.qobj.QasmQobj.from_dict(job_dict)
         self.assertRaisesRegex(QisKitBackendError, 'Number of classical bits must be less than or equal to the'
                                                    ' number of qubits when using conditional gate operations',
+                               simulator.run, job)
+
+    def test_validate_nr_classical_qubits_less_than_needed_for_storing_measured_qubits(self):
+        api = Mock()
+        api.create_project.return_value = {'id': 42}
+        api.execute_qasm_async.return_value = 42
+        api.get_backend_type_by_name.return_value = {'max_number_of_shots': 4096}
+        simulator = QuantumInspireBackend(api, Mock())
+        instructions = [{'name': 'cx', 'qubits': [0, 1]}]
+        qobj_dict = self._basic_qobj_dictionary
+        job_dict = self._basic_qobj_dictionary
+        qobj_dict['experiments'][0]['instructions'] = instructions
+        job_dict['experiments'][0]['header']['memory_slots'] = 1
+        job = qiskit.qobj.QasmQobj.from_dict(job_dict)
+        self.assertRaisesRegex(QisKitBackendError, 'Number of classical bits is not sufficient for storing the '
+                                                   'outcomes of the experiment',
                                simulator.run, job)
 
     def test_for_non_fsp_gate_after_measurement(self):
@@ -554,8 +596,8 @@ class TestQiSimulatorPy(unittest.TestCase):
         self.assertEqual('42', qi_job.job_id())
 
     def test_retrieve_job_with_error(self):
-        api = Mock(side_effect=ErrorMessage(error='404'))
-        api.get_project.side_effect = ErrorMessage(error='404')
+        api = Mock(side_effect=ApiError(f'Project with id 404 does not exist!'))
+        api.get_project.side_effect = ApiError(f'Project with id 404 does not exist!')
         backend = QuantumInspireBackend(api, QuantumInspireProvider())
         with self.assertRaises(QisKitBackendError) as error:
             backend.retrieve_job('wrong')


### PR DESCRIPTION
* Adjusted readthedocs for using version 3.8 of python
* Fix for damaged projects when error occured while post-processing the cQASM algorithm
* Check added during pre-processing for experiments where the number of classical bits is not enough to hold the measured qubits
* Removed format_vector method not used in notebook
* Renamed IPython to Jupyter