### PR TITLE
[SDS-NNN] Calibrations in result

### DIFF
--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -208,9 +208,11 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
             measurements = user_data.pop('measurements')
             histogram_obj, memory_data = self.__convert_result_data(result, measurements)
             full_state_histogram_obj = self.__convert_histogram(result, measurements)
+            calibration = self.__api.get_calibration_from_result(result['id'])
             experiment_result_data = ExperimentResultData(counts=histogram_obj,
-                                                          memory=memory_data)
-            experiment_result_data.probabilities = full_state_histogram_obj
+                                                          memory=memory_data,
+                                                          probabilities=full_state_histogram_obj,
+                                                          calibration=calibration)
             header = QobjExperimentHeader.from_dict(user_data)
             experiment_result_dictionary = {'name': job.get('name'), 'seed': 42, 'shots': job.get('number_of_shots'),
                                             'data': experiment_result_data, 'status': 'DONE', 'success': True,

--- a/src/quantuminspire/qiskit/qi_result.py
+++ b/src/quantuminspire/qiskit/qi_result.py
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import List, Union, Dict, Any
+from typing import Any, Dict, List, Optional, Union
 from qiskit.exceptions import QiskitError
 from qiskit.result import postprocess, Result
 from qiskit.result.models import ExperimentResult
@@ -75,9 +75,9 @@ class QIResult(Result):  # type: ignore
             except (AttributeError, QiskitError):  # header is not available
                 header = None
 
-            probabilities = getattr(self._get_experiment(key).data, 'probabilities', None)
-            if probabilities is not None:
-                dict_list.append(postprocess.format_counts(self._get_experiment(key).data.probabilities, header))
+            if "probabilities" in self.data(key).keys():
+                probabilities = self.data(key)["probabilities"]
+                dict_list.append(postprocess.format_counts(probabilities, header))
             else:
                 raise QiskitBackendError('No probabilities for experiment "{0}"'.format(key))
 
@@ -87,14 +87,36 @@ class QIResult(Result):  # type: ignore
 
         return dict_list
 
-    def get_calibration(self, api) -> Dict[str, Any]:
-        """ Return the calibration data for this result
+    def get_calibration(self, experiment: Any = None) -> Optional[Union[Dict[str, Any], List[Dict[str, Any]]]]:
+        """Get the calibration data of an experiment. The calibration data is added as a separate result item by
+        Quantum Inspire backend. Based on Qiskit get_count method from Result.
+
+        :param experiment (str or QuantumCircuit or Schedule or int or None): the index of the
+                experiment, as specified by ``get_data()``.
 
         :return:
-            The calibration data as a dictionary. Exact format depends on the backend.
+            One or more dictionaries which holds the calibration data for each result.
+            Exact format depends on the backend. A simulator backend has no calibration data (None is returned)
+
+        :raises QiskitBackendError: raised if there is no calibration data in a result for the experiment(s).
         """
-        project_id=self.job_id
-        jobs=api.get_jobs_from_project(project_id)
-        qi_result=api.get_result_from_job(jobs[0]['id'])
-        calibration =  api.get_calibration_from_result(qi_result['id'])
-        return calibration
+        if experiment is None:
+            exp_keys = range(len(self.results))
+        else:
+            exp_keys = [experiment]  # type: ignore
+
+        dict_list: List[Dict[str, float]] = []
+        for key in exp_keys:
+            exp = self._get_experiment(key)
+
+            if "calibration" in self.data(key).keys():
+                calibration = self.data(key)["calibration"]
+                dict_list.append(calibration)
+            else:
+                raise QiskitBackendError('No calibration data for experiment "{0}"'.format(key))
+
+        # Return first item of dict_list if size is 1
+        if len(dict_list) == 1:
+            return dict_list[0]
+
+        return dict_list

--- a/src/quantuminspire/qiskit/qi_result.py
+++ b/src/quantuminspire/qiskit/qi_result.py
@@ -86,3 +86,15 @@ class QIResult(Result):  # type: ignore
             return dict_list[0]
 
         return dict_list
+
+    def get_calibration(self, api) -> Dict[str, Any]:
+        """ Return the calibration data for this result
+
+        :return:
+            The calibration data as a dictionary. Exact format depends on the backend.
+        """
+        project_id=self.job_id
+        jobs=api.get_jobs_from_project(project_id)
+        qi_result=api.get_result_from_job(jobs[0]['id'])
+        calibration =  api.get_calibration_from_result(qi_result['id'])
+        return calibration

--- a/src/tests/quantuminspire/qiskit/test_qi_result.py
+++ b/src/tests/quantuminspire/qiskit/test_qi_result.py
@@ -24,17 +24,27 @@ from quantuminspire.qiskit.qi_result import QIResult
 
 class TestQIResult(unittest.TestCase):
     def setUp(self):
-        experiment_result_data_1 = ExperimentResultData.from_dict({'counts': {'0x0': 42, '0x3': 58}})
-        experiment_result_data_1.probabilities = {'0x0': 0.42, '0x3': 0.58}
+        experiment_result_data_1 = ExperimentResultData.from_dict({'counts': {'0x0': 42, '0x3': 58},
+                                                                   'probabilities' :{'0x0': 0.42, '0x3': 0.58},
+                                                                   'calibration' : {'fridge_temperature': 26.9,
+                                                                                    'unit': 'mK'}})
         experiment_result_data_2 = ExperimentResultData.from_dict({'counts': {'0x0': 24, '0x1': 25,
-                                                                              '0x2': 23, '0x3': 28}})
-        experiment_result_data_2.probabilities = {'0x0': 0.24, '0x1': 0.25, '0x2': 0.23, '0x3': 0.28}
+                                                                              '0x2': 23, '0x3': 28},
+                                                                   'probabilities' : {'0x0': 0.24, '0x1': 0.25,
+                                                                                      '0x2': 0.23, '0x3': 0.28},
+                                                                   'calibration' : {'fridge_temperature': 25.0,
+                                                                                    'unit': 'mK'}})
         experiment_result_data_3 = ExperimentResultData.from_dict({'counts': {'0x0': 24, '0x1': 25,
+                                                                              '0x2': 23, '0x3': 28},
+                                                                   'calibration' : None})
+
+        experiment_result_data_4 = ExperimentResultData.from_dict({'counts': {'0x0': 24, '0x1': 25,
                                                                               '0x2': 23, '0x3': 28}})
 
         header_1 = QobjHeader.from_dict({'name': 'Test1', 'memory_slots': 2, 'creg_sizes': [['c0', 2]]})
         header_2 = QobjHeader.from_dict({'name': 'Test2', 'memory_slots': 3, 'creg_sizes': [['c0', 3]]})
         header_3 = None
+        header_4 = None
         self.experiment_result_dictionary_1 = {'name': 'Test1', 'shots': 42, 'data': experiment_result_data_1,
                                                'status': 'DONE', 'success': True, 'time_taken': 0.42,
                                                'header': header_1}
@@ -44,9 +54,13 @@ class TestQIResult(unittest.TestCase):
         self.experiment_result_dictionary_3 = {'name': 'Test3', 'shots': 23, 'data': experiment_result_data_3,
                                                'status': 'DONE', 'success': True, 'time_taken': 0.12,
                                                'header': header_3}
+        self.experiment_result_dictionary_4 = {'name': 'Test4', 'shots': 21, 'data': experiment_result_data_4,
+                                               'status': 'DONE', 'success': True, 'time_taken': 0.12,
+                                               'header': header_4}
         self.experiment_result_1 = ExperimentResult(**self.experiment_result_dictionary_1)
         self.experiment_result_2 = ExperimentResult(**self.experiment_result_dictionary_2)
         self.experiment_result_3 = ExperimentResult(**self.experiment_result_dictionary_3)
+        self.experiment_result_4 = ExperimentResult(**self.experiment_result_dictionary_4)
 
     def test_constructor(self):
         backend_name = 'test_backend'
@@ -81,6 +95,15 @@ class TestQIResult(unittest.TestCase):
         probabilities = qi_result.get_probabilities()
         self.assertListEqual(probabilities, [{'00': 0.42, '11': 0.58},
                                              {'000': 0.24, '001': 0.25, '010': 0.23, '011': 0.28}])
+        calibration = qi_result.get_calibration('Test1')
+        self.assertDictEqual(calibration, {'fridge_temperature': 26.9, 'unit': 'mK'})
+        calibration = qi_result.get_calibration('Test2')
+        self.assertDictEqual(calibration, {'fridge_temperature': 25.0, 'unit': 'mK'})
+        calibration = qi_result.get_calibration(1)
+        self.assertDictEqual(calibration, {'fridge_temperature': 25.0, 'unit': 'mK'})
+        calibration = qi_result.get_calibration()
+        self.assertListEqual(calibration, [{'fridge_temperature': 26.9, 'unit': 'mK'},
+                                           {'fridge_temperature': 25.0, 'unit': 'mK'}])
 
     def test_no_probabilities(self):
         backend_name = 'test_backend'
@@ -92,3 +115,25 @@ class TestQIResult(unittest.TestCase):
         qi_result = QIResult(backend_name, backend_version, qobj_id, job_id, success, experiment_result)
         self.assertRaisesRegex(QiskitBackendError, 'No probabilities for experiment "0"',
                                qi_result.get_probabilities, 0)
+
+    def test_empty_calibration(self):
+        backend_name = 'test_sim_backend'
+        backend_version = '1.2.0'
+        qobj_id = '42'
+        job_id = '42'
+        success = True
+        experiment_result = [self.experiment_result_3]
+        qi_result = QIResult(backend_name, backend_version, qobj_id, job_id, success, experiment_result)
+        calibration = qi_result.get_calibration()
+        self.assertIsNone(calibration)
+
+    def test_no_calibration_data(self):
+        backend_name = 'test_backend'
+        backend_version = '1.2.0'
+        qobj_id = '42'
+        job_id = '42'
+        success = True
+        experiment_result = [self.experiment_result_4]
+        qi_result = QIResult(backend_name, backend_version, qobj_id, job_id, success, experiment_result)
+        self.assertRaisesRegex(QiskitBackendError, 'No calibration data for experiment "0"',
+                               qi_result.get_calibration, 0)


### PR DESCRIPTION
A minimal example:
```
import quantuminspire
from quantuminspire.credentials import get_authentication
from quantuminspire.qiskit import QI
from qiskit.circuit import QuantumCircuit
from qiskit import execute

qc=QuantumCircuit(2,2)
qc.h(0)
qc.cz(0,1)
qc.measure_all()
qc.draw()

authentication = get_authentication()
QI.set_authentication(authentication)
api = QI.get_api()
backend = QI.get_backend("Starmon-5")

job = execute(qc, backend)
result = job.result()
calibration = result.get_calibration(api)
print(calibration)
```

@QFer Not sure how to test this, since in the tests we have no active backends I think.