### PR TITLE
[SDS-NNN] Backend status

### DIFF
--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -25,6 +25,7 @@ from coreapi.exceptions import ErrorMessage
 from qiskit.providers import BaseBackend
 from qiskit.providers.models import QasmBackendConfiguration
 from qiskit.providers.models.backendconfiguration import GateConfig
+from qiskit.providers.models.backendstatus import BackendStatus
 from qiskit.qobj import QasmQobj, QasmQobjExperiment
 from qiskit.result.models import ExperimentResult, ExperimentResultData
 from qiskit.qobj import QobjExperimentHeader
@@ -135,6 +136,21 @@ class QuantumInspireBackend(BaseBackend):  # type: ignore
 
         job.experiments = experiments
         return job
+
+    def status(self) -> BackendStatus:
+        """ Return the backend status. Pending jobs is always 0. This information is currently not known.
+
+        Returns:
+            BackendStatus: the status of the backend. Pending jobs is always 0.
+        """
+        backend: Dict[str, Any] = self.__api.get_backend_type_by_name(self.name())
+        return BackendStatus(
+            backend_name=self.name(),
+            backend_version=quantum_inspire_version,
+            operational=backend["status"] != "OFFLINE",
+            pending_jobs=0,
+            status_msg=backend["status_message"],
+        )
 
     def retrieve_job(self, job_id: str) -> QIJob:
         """ Retrieve a specified job by its job_id.

--- a/src/tests/quantuminspire/qiskit/test_backend_qx.py
+++ b/src/tests/quantuminspire/qiskit/test_backend_qx.py
@@ -139,6 +139,21 @@ class TestQiSimulatorPy(unittest.TestCase):
         )
         self.assertDictEqual(configuration.to_dict(), expected_configuration.to_dict())
 
+    def test_backend_status(self):
+        api = Mock()
+        type(api).__name__ = 'QuantumInspireAPI'
+        backend_type = {'max_number_of_shots': 4096,
+                        'status': 'OFFLINE',
+                        'status_message': 'This backend is offline.'}
+        api.get_backend_type_by_name.return_value = backend_type
+        simulator = QuantumInspireBackend(api, Mock())
+        status=simulator.status()
+        self.assertEqual(status.backend_name, 'qi_simulator')
+        self.assertEqual(status.status_msg, backend_type['status_message'])
+        self.assertEqual(status.backend_version, quantum_inspire_version)
+        self.assertFalse(status.operational)
+        self.assertEqual(status.pending_jobs, 0)
+
     def test_run_returns_correct_result(self):
         api = Mock()
         type(api).__name__ = 'QuantumInspireAPI'


### PR DESCRIPTION
* Added status() to backend to return the BackendStatus
* pending jobs are not known. We leave it 0 because Qiskit doesn't accept negative values.
* backend_version is not coming from the backend, currently SDK version is taken as backend version