### PR TITLE
[SDS-424] Qiskit upstream changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,13 @@ matrix:
     - name: python 3.7
       python: 3.7
       if: branch = dev
-      sudo: true
       dist: xenial
     - name: python 3.8
       python: 3.8
       if: branch = dev
-      sudo: true
       dist: xenial
     - name: python 3.9
       python: 3.9
-      sudo: true
       dist: xenial
 install:
 - pip install --upgrade .[qiskit,projectq,dev] coveralls

--- a/src/quantuminspire/api.py
+++ b/src/quantuminspire/api.py
@@ -1009,9 +1009,9 @@ class QuantumInspireAPI:
             project = self.create_project(project_name, default_number_of_shots, backend_type)
 
         if backend_type['url'] != project['backend_type']:
-            logger.warning(f"The backend for which the project was created is different "
-                           f"from the backend type given: {backend_type['name']}. The experiment is run on backend "
-                           f"{backend_type['name']}.")
+            logger.warning("The backend for which the project was created is different "
+                           "from the backend type given: %s. The experiment is run on backend %s.",
+                           backend_type['name'], backend_type['name'])
 
         qasm = qasm.lstrip()
         qasm = re.sub(r'[ \t]*\n[ \t]*', r'\n', qasm)

--- a/src/quantuminspire/qiskit/qi_job.py
+++ b/src/quantuminspire/qiskit/qi_job.py
@@ -17,17 +17,18 @@
 import time
 from typing import List, Optional, Any, Dict, Callable
 
-from qiskit.providers import BaseJob, JobError, JobTimeoutError
+from qiskit.providers import JobError, JobTimeoutError, JobV1 as Job
+from qiskit.providers.backend import Backend
 from qiskit.providers.jobstatus import JobStatus, JOB_FINAL_STATES
 from qiskit.result.models import ExperimentResult
 from qiskit.qobj import QasmQobj, QasmQobjExperiment
-from quantuminspire.qiskit.qi_result import QIResult
 from quantuminspire.api import QuantumInspireAPI
 from quantuminspire.job import QuantumInspireJob
+from quantuminspire.qiskit.qi_result import QIResult
 from quantuminspire.version import __version__ as quantum_inspire_version
 
 
-class QIJob(BaseJob):  # type: ignore
+class QIJob(Job):  # type: ignore
     """
     A Qiskit job that is executed on the Quantum Inspire platform. A QIJob is normally created by calling
     ``execute`` (which triggers a `run` on the QuantumInspireBackend ``qi_backend``).
@@ -67,7 +68,7 @@ class QIJob(BaseJob):  # type: ignore
 
     """
 
-    def __init__(self, backend: Any, job_id: str, api: QuantumInspireAPI, qobj: Optional[QasmQobj] = None) -> None:
+    def __init__(self, backend: Backend, job_id: str, api: QuantumInspireAPI, qobj: Optional[QasmQobj] = None) -> None:
         """
         A QIJob object is normally not constructed directly.
 
@@ -106,7 +107,7 @@ class QIJob(BaseJob):  # type: ignore
             raise JobError('Job has already been submitted!')
         self._job_id = self._backend.run(self._qobj)
 
-    def _result(self, result_function: Callable[[BaseJob], List[ExperimentResult]], timeout: Optional[float] = None,
+    def _result(self, result_function: Callable[[Job], List[ExperimentResult]], timeout: Optional[float] = None,
                 wait: float = 0.5) -> QIResult:
         """ Return the result for the experiments.
 
@@ -193,6 +194,9 @@ class QIJob(BaseJob):  # type: ignore
         """
         Return the position for this Job in the Quantum Inspire queue (when in status QUEUED).
         Currently we don't have this info available.
+
+        :param refresh: If ``True``, re-query the server to get the latest value.
+                Otherwise return the cached value, when available. Not used.
 
         :return:
             The queue position of the job. Currently None (not available).

--- a/src/quantuminspire/qiskit/quantum_inspire_provider.py
+++ b/src/quantuminspire/qiskit/quantum_inspire_provider.py
@@ -18,8 +18,8 @@ from copy import copy
 from typing import List, Optional, Any, Dict
 
 import coreapi
-from qiskit.providers import BaseProvider
 from qiskit.providers.models import QasmBackendConfiguration
+from qiskit.providers.provider import ProviderV1 as Provider
 
 from quantuminspire.api import QuantumInspireAPI
 from quantuminspire.credentials import get_token_authentication, get_basic_authentication
@@ -29,7 +29,7 @@ from quantuminspire.qiskit.backend_qx import QuantumInspireBackend
 QI_URL = 'https://api.quantum-inspire.com'
 
 
-class QuantumInspireProvider(BaseProvider):  # type: ignore
+class QuantumInspireProvider(Provider):  # type: ignore
     """ Provides a backend and an api for a single Quantum Inspire account. """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
* Switch to Qiskit classes for (soon) deprecated classes:
  * BaseBackend -> BackendV1
  * BaseProvider -> ProviderV1
  * BaseJob -> JobV1
* in Travis sudo argument is not supported anymore - deleted from travis.yml
* Solved pylint error for api warning log message using f-string