### PR TITLE
[SDS-315] Small fix for generating readthedocs

### DIFF
--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -136,7 +136,7 @@ class QuantumInspireBackend(Backend):  # type: ignore
         :param shots: Number of repetitions of each circuit, for sampling. Default: 1024
                 or ``max_shots`` from the backend configuration, whichever is smaller.
         :param memory: If ``True``, per-shot measurement bitstrings are returned
-        :param **run_config: Extra arguments used to configure the run.
+        :param run_config: Extra arguments used to configure the run.
 
         :return:
             A job that has been submitted.


### PR DESCRIPTION
* Readthedocs was already implemented via another MR long ago.
* While generating docs a warning was shown in the run method docstirng, this was fixed in this MR