### PR TITLE
[SDS-NNN] Nightly build switch to python 3.7 (min. version for qiskit)

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -18,10 +18,10 @@ jobs:
       with:
         repository: qiskit/qiskit-terra
         path: qiskit-terra
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: pip install prerequisites
       uses: BSFishy/pip-action@v1
       with:


### PR DESCRIPTION
* Python 3.7 instead of 3.6 (for qiskit terra)