### PR TITLE
[SDS-540] fix for non-lineair measured bits used in conditional

### DIFF
--- a/src/quantuminspire/api.py
+++ b/src/quantuminspire/api.py
@@ -99,7 +99,7 @@ class QuantumInspireAPI:
                 raise AuthenticationError('No credentials have been provided or found on disk')
         self.__client = coreapi_client_class(auth=authentication)
         self.project_name = project_name
-        self.base_uri = base_uri if base_uri[-1] is '/' else base_uri + '/'
+        self.base_uri = base_uri if base_uri[-1] == '/' else base_uri + '/'
         self.enable_fsp_warning = True
         try:
             self._load_schema()

--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -38,6 +38,7 @@ from quantuminspire.api import QuantumInspireAPI
 from quantuminspire.exceptions import QiskitBackendError, ApiError
 from quantuminspire.job import QuantumInspireJob
 from quantuminspire.qiskit.circuit_parser import CircuitToString
+from quantuminspire.qiskit.measurements import Measurements
 from quantuminspire.qiskit.qi_job import QIJob
 from quantuminspire.version import __version__ as quantum_inspire_version
 
@@ -50,8 +51,8 @@ class QuantumInspireBackend(Backend):  # type: ignore
         backend_name='qi_simulator',
         backend_version=quantum_inspire_version,
         n_qubits=26,
-        basis_gates=['x', 'y', 'z', 'h', 'rx', 'ry', 'rz', 's', 'sdg', 't', 'tdg', 'cx', 'ccx', 'u1', 'u2', 'u3', 'id',
-                     'swap', 'cz', 'snapshot'],
+        basis_gates=['x', 'y', 'z', 'h', 'rx', 'ry', 'rz', 's', 'sdg', 't', 'tdg', 'cx', 'ccx', 'u1', 'p', 'u2', 'u3',
+                     'id', 'swap', 'cz', 'snapshot'],
         gates=[GateConfig(name='NotUsed', parameters=['NaN'], qasm_def='NaN')],
         local=False,
         simulator=True,
@@ -177,12 +178,15 @@ class QuantumInspireBackend(Backend):  # type: ignore
             experiments = qobj.experiments
             job = QIJob(self, str(project['id']), self.__api)
             for experiment in experiments:
-                self.__validate_number_of_clbits(experiment)
+                measurements = Measurements()
+                measurements.collect_measurements(experiment)
+                if Backend.configuration(self).conditional:
+                    self.__validate_nr_of_clbits_conditional_gates(experiment)
                 full_state_projection = Backend.configuration(self).simulator and \
                     self.__validate_full_state_projection(experiment)
                 if not full_state_projection:
-                    QuantumInspireBackend.__validate_unsupported_measurements(experiment)
-                job_for_experiment = self._submit_experiment(experiment, number_of_shots, project=project,
+                    measurements.validate_unsupported_measurements()
+                job_for_experiment = self._submit_experiment(experiment, number_of_shots, measurements, project=project,
                                                              full_state_projection=full_state_projection)
                 job.add_job(job_for_experiment)
                 if project is not None and job_for_experiment.get_project_identifier() != project['id']:
@@ -230,16 +234,18 @@ class QuantumInspireBackend(Backend):  # type: ignore
         return QIJob(self, job_id, self.__api)
 
     @staticmethod
-    def _generate_cqasm(experiment: QasmQobjExperiment, full_state_projection: bool = True) -> str:
+    def _generate_cqasm(experiment: QasmQobjExperiment, measurements: Measurements,
+                        full_state_projection: bool = True) -> str:
         """ Generates the cQASM from the Qiskit experiment.
 
         :param experiment: The experiment that contains instructions to be converted to cQASM.
+        :param measurements: The measurement instance containing measurement information and measurement functionality.
         :param full_state_projection: When False, the experiment is not suitable for full state projection
 
         :return:
             The cQASM code that can be sent to the Quantum Inspire API.
         """
-        parser = CircuitToString(full_state_projection)
+        parser = CircuitToString(measurements, full_state_projection)
         number_of_qubits = experiment.header.n_qubits
         instructions = experiment.instructions
         with io.StringIO() as stream:
@@ -251,12 +257,12 @@ class QuantumInspireBackend(Backend):  # type: ignore
             return stream.getvalue()
 
     def _submit_experiment(self, experiment: QasmQobjExperiment, number_of_shots: int,
+                           measurements: Measurements,
                            project: Optional[Dict[str, Any]] = None,
                            full_state_projection: bool = True) -> QuantumInspireJob:
-        compiled_qasm = self._generate_cqasm(experiment, full_state_projection=full_state_projection)
-        measurements = self._collect_measurements(experiment)
+        compiled_qasm = self._generate_cqasm(experiment, measurements, full_state_projection=full_state_projection)
         user_data = {'name': experiment.header.name, 'memory_slots': experiment.header.memory_slots,
-                     'creg_sizes': experiment.header.creg_sizes, 'measurements': measurements}
+                     'creg_sizes': experiment.header.creg_sizes, 'measurements': measurements.to_dict()}
         quantum_inspire_job = self.__api.execute_qasm_async(compiled_qasm, backend_type=self.__backend,
                                                             number_of_shots=number_of_shots, project=project,
                                                             job_name=experiment.header.name,
@@ -282,7 +288,8 @@ class QuantumInspireBackend(Backend):  # type: ignore
                     'Result from backend contains no histogram data!\n{}'.format(result.get('raw_text')))
 
             user_data = json.loads(str(job.get('user_data')))
-            measurements = user_data.pop('measurements')
+            measurements = Measurements()
+            measurements.from_dict(user_data.pop('measurements'))
             histogram_obj, memory_data = self.__convert_result_data(result, measurements)
             full_state_histogram_obj = self.__convert_histogram(result, measurements)
             calibration = self.__api.get_calibration_from_result(result['id'])
@@ -329,13 +336,10 @@ class QuantumInspireBackend(Backend):  # type: ignore
         if number_of_shots < 1 or number_of_shots > self.__backend['max_number_of_shots']:
             raise QiskitBackendError('Invalid shots (number_of_shots={})'.format(number_of_shots))
 
-    def __validate_number_of_clbits(self, experiment: QasmQobjExperiment) -> None:
-        """ Validate the number of classical bits
+    def __validate_nr_of_clbits_conditional_gates(self, experiment: QasmQobjExperiment) -> None:
+        """ Validate the number of classical bits in the algorithm when conditional gates are used
 
-        Checks whether the number of classical bits has a value cQASM can support.
-
-        1.  When number of classical bits is less than 1 an error is raised.
-        2.  When binary controlled gates are used and the number of classical registers
+        1.  When binary controlled gates are used and the number of classical registers
             is greater than the number of qubits an error is raised.
 
             When using binary controlled gates in Qiskit, we can have something like:
@@ -354,25 +358,16 @@ class QuantumInspireBackend(Backend):  # type: ignore
 
         :raises QiskitBackendError: When the value is not correct.
         """
-        number_of_clbits = experiment.header.memory_slots
-        if number_of_clbits < 1:
-            raise QiskitBackendError("Invalid amount of classical bits ({})!".format(number_of_clbits))
+        header = experiment.header
+        number_of_qubits = header.n_qubits
+        number_of_clbits = header.memory_slots
 
-        measurements = self._collect_measurements(experiment)
-        number_of_classical_bits = measurements['number_of_clbits']
-        max_measurement_index = max(measurement[1] for measurement in measurements['measurements'])
-        if max_measurement_index >= number_of_classical_bits:
-            raise QiskitBackendError(f"Number of classical bits ({number_of_classical_bits}) is not sufficient for "
-                                     f"storing the outcomes of the experiment")
-
-        if Backend.configuration(self).conditional:
-            number_of_qubits = experiment.header.n_qubits
-            if number_of_clbits > number_of_qubits:
-                # no problem when there are no conditional gate operations
-                for instruction in experiment.instructions:
-                    if hasattr(instruction, 'conditional'):
-                        raise QiskitBackendError("Number of classical bits must be less than or equal to the"
-                                                 " number of qubits when using conditional gate operations")
+        if number_of_clbits > number_of_qubits:
+            for instruction in experiment.instructions:
+                if hasattr(instruction, 'conditional'):
+                    # no problem when there are no conditional gate operations
+                    raise QiskitBackendError("Number of classical bits must be less than or equal to the"
+                                             " number of qubits when using conditional gate operations")
 
     @staticmethod
     def __validate_full_state_projection(experiment: QasmQobjExperiment) -> bool:
@@ -393,83 +388,12 @@ class QuantumInspireBackend(Backend):  # type: ignore
                 measurement_found = True
             elif measurement_found:
                 fsp = False
+                break
+
         return fsp
 
     @staticmethod
-    def __validate_unsupported_measurements(experiment: QasmQobjExperiment) -> None:
-        """ Validate unsupported measurements
-
-        When using non-FSP (not full state projection) certain measurements cannot be handled correctly because
-        cQASM isn't as flexible as Qiskit in measuring to specific classical bits.
-        Therefore some Qiskit constructions are not supported in QI:
-
-            1. When a quantum register is measured to different classical registers
-            2. When a classical register is used for the measurement of more than one quantum register
-
-        :param experiment: The experiment with gate operations and header.
-
-        :raises QiskitBackendError: When the circuit contains an invalid non-FSP measurement
-        """
-        measurements: List[List[int]] = []
-        for instruction in experiment.instructions:
-            if instruction.name == 'measure':
-                for q, m in measurements:
-                    if q == instruction.qubits[0] and m != instruction.memory[0]:
-                        raise QiskitBackendError('Measurement of qubit {} to different classical registers '
-                                                 'is not supported'.format(q))
-                    if q != instruction.qubits[0] and m == instruction.memory[0]:
-                        raise QiskitBackendError('Measurement of different qubits to the same classical register {0} '
-                                                 'is not supported'.format(m))
-                measurements.append([instruction.qubits[0], instruction.memory[0]])
-
-    @staticmethod
-    def _collect_measurements(experiment: QasmQobjExperiment) -> Dict[str, Any]:
-        """ Determines the measured qubits and classical bits.
-
-        The full-state measured
-        qubits is returned when no measurements are present in the compiled circuit.
-
-        :param experiment: The experiment with gate operations and header.
-
-        :return:
-            The dict contains measurements, which is a list of lists, for each measurement the list contains
-            a list of [qubit_index, classical_bit_index], which represents the measurement of a qubit to a
-            classical bit, and the second field in the dict is the number of classical bits (int).
-        """
-        header = experiment.header
-        number_of_qubits = header.n_qubits
-        number_of_clbits = header.memory_slots
-
-        operations = experiment.instructions
-        measurements = [[number_of_qubits - 1 - m.qubits[0],
-                         number_of_clbits - 1 - m.memory[0]]
-                        for m in operations if m.name == 'measure']
-        if not measurements:
-            measurements = [[index, index] for index in range(number_of_qubits)]
-        return {'measurements': measurements, 'number_of_clbits': number_of_clbits}
-
-    @staticmethod
-    def __qubit_to_classical_hex(qubit_register: str, measurements: Dict[str, Any], number_of_qubits: int) -> str:
-        """ This function converts the qubit register data to the hexadecimal representation of the classical state.
-
-        :param qubit_register: The measured value of the qubits represented as int.
-        :param measurements: The dictionary contains a measured qubits/classical bits map (list) and the
-                          number of classical bits (int).
-        :param number_of_qubits: Number of qubits used in the algorithm.
-
-        :return:
-            The hexadecimal value of the classical state.
-        """
-        qubit_state = ('{0:0{1}b}'.format(int(qubit_register), number_of_qubits))
-        classical_state = ['0'] * measurements['number_of_clbits']
-        for q, c in measurements['measurements']:
-            classical_state[c] = qubit_state[q]
-        classical_state_str = ''.join(classical_state)
-        classical_state_hex = hex(int(classical_state_str, 2))
-        return classical_state_hex
-
-    @staticmethod
-    def __convert_histogram(result: Dict[str, Any], measurements: Dict[str, Any]) -> Dict[str, float]:
+    def __convert_histogram(result: Dict[str, Any], measurements: Measurements) -> Dict[str, float]:
         """Convert histogram
 
         The Quantum Inspire backend always uses full state projection. The SDK user
@@ -478,28 +402,25 @@ class QuantumInspireBackend(Backend):  # type: ignore
         measured with the classical bits.
 
         :param result: The result output from the Quantum Inspire backend with full-
-                    state projection histogram output.
-        :param measurements: The dictionary contains a measured qubits/classical bits map (list) and the
-                          number of classical bits (int).
+                       state projection histogram output.
+        :param measurements: The measurement instance containing measurement information and measurement functionality.
 
         :return:
             The resulting full state histogram with probabilities.
         """
         output_histogram_probabilities: Dict[str, float] = defaultdict(lambda: 0)
-        number_of_qubits = result['number_of_qubits']
         state_probability: Dict[str, float] = result['histogram']
         for qubit_register, probability in state_probability.items():
-            classical_state_hex = QuantumInspireBackend.__qubit_to_classical_hex(qubit_register, measurements,
-                                                                                 number_of_qubits)
+            classical_state_hex = measurements.qubit_to_classical_hex(qubit_register)
             output_histogram_probabilities[classical_state_hex] += probability
 
         sorted_histogram_probabilities: List[Tuple[str, float]] = sorted(output_histogram_probabilities.items(),
                                                                          key=lambda kv: int(kv[0], 16))
         return dict(sorted_histogram_probabilities)
 
-    def __convert_result_data(self, result: Dict[str, Any], measurements: Dict[str, Any]) -> Tuple[Dict[str, int],
-                                                                                                   List[str]]:
-        """Conver result data
+    def __convert_result_data(self, result: Dict[str, Any], measurements: Measurements) -> Tuple[Dict[str, int],
+                                                                                                 List[str]]:
+        """Convert result data
 
         The Quantum Inspire backend returns the single shot values as raw data. This function
         converts this list of single shot values to hexadecimal memory data according the Qiskit spec.
@@ -525,9 +446,8 @@ class QuantumInspireBackend(Backend):  # type: ignore
                 When random is in the range [0.7, 1) the last value of the probability histogram is taken (0x6).
 
         :param result: The result output from the Quantum Inspire backend with full-
-                    state projection histogram output.
-        :param measurements: The dictionary contains a measured qubits/classical bits map (list) and the
-                          number of classical bits (int).
+                       state projection histogram output.
+        :param measurements: The measurement instance containing measurement information and measurement functionality.
 
         :return:
             The result consists of two formats for the result. The first result is the histogram with count data,
@@ -535,12 +455,10 @@ class QuantumInspireBackend(Backend):  # type: ignore
         """
         memory_data = []
         histogram_data: Dict[str, int] = defaultdict(lambda: 0)
-        number_of_qubits: int = result['number_of_qubits']
         raw_data = self.__api.get_raw_data_from_result(result['id'])
         if raw_data:
             for raw_qubit_register in raw_data:
-                classical_state_hex = QuantumInspireBackend.__qubit_to_classical_hex(str(raw_qubit_register),
-                                                                                     measurements, number_of_qubits)
+                classical_state_hex = measurements.qubit_to_classical_hex(str(raw_qubit_register))
                 memory_data.append(classical_state_hex)
             histogram_data = {elem: count for elem, count in Counter(memory_data).items()}
         else:
@@ -550,8 +468,7 @@ class QuantumInspireBackend(Backend):  # type: ignore
             for qubit_register, probability in state_probabilities.items():
                 sum_probability += probability
                 if random_probability < sum_probability:
-                    classical_state_hex = QuantumInspireBackend.__qubit_to_classical_hex(qubit_register, measurements,
-                                                                                         number_of_qubits)
+                    classical_state_hex = measurements.qubit_to_classical_hex(qubit_register)
                     memory_data.append(classical_state_hex)
                     histogram_data[classical_state_hex] = 1
                     break

--- a/src/quantuminspire/qiskit/circuit_parser.py
+++ b/src/quantuminspire/qiskit/circuit_parser.py
@@ -691,7 +691,6 @@ class CircuitToString:
             # form multi bits control - qasm-single-gate-multiple-qubits
             binary_control = f'b[' + ','.join(str(self.measurements.get_qreg_for_conditional_creg(i)) for i in
                                               range(lowest_mask_bit, lowest_mask_bit + mask_length)) + '], '
-            # binary_control = f'b[{lowest_mask_bit}:{lowest_mask_bit + mask_length - 1}], '
 
         with StringIO() as gate_stream:
             # add the gate

--- a/src/quantuminspire/qiskit/measurements.py
+++ b/src/quantuminspire/qiskit/measurements.py
@@ -1,0 +1,197 @@
+# Quantum Inspire SDK
+#
+# Copyright 2018 QuTech Delft
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, List
+
+from qiskit.qobj import QasmQobjExperiment
+from quantuminspire.exceptions import QiskitBackendError
+
+
+class Measurements:
+    def __init__(self) -> None:
+        """
+        The Measurements class registers measurements and the translations of measurements of qubits to classical
+        registers.
+        _measurements_reg and _measurements_state are list of lists, for each measurement the lists contains
+        a list of [qubit_index, classical_bit_index], which represents the measurement of a qubit to a
+        classical bit.
+        _measurements_reg contains the bit indices of the qubit and classical bit as used in the algorithm
+        _measurements_state contains the positional indexes in the resulting qubit_state and classical_state arrays
+        """
+        self._number_of_qubits = 0
+        self._number_of_clbits = 0
+        self._measurements_reg: List[List[int]] = []
+        self._measurements_state: List[List[int]] = []
+
+    @property
+    def nr_of_qubits(self) -> int:
+        """
+        :return: Return number of qubits in the algorithm
+        """
+        return self._number_of_qubits
+
+    @property
+    def nr_of_clbits(self) -> int:
+        """
+        :return: Return number of classical bits in the algorithm
+        """
+        return self._number_of_clbits
+
+    def collect_measurements(self, experiment: QasmQobjExperiment) -> None:
+        """ Determines the measured qubits and classical bits.
+
+        The full-state measured qubits is returned when no measurements are present in the compiled circuit.
+
+        .. code::
+
+            q = QuantumRegister(3)
+            c = ClassicalRegister(3)
+            circuit = QuantumCircuit(q, c)
+
+            circuit.measure(2, 0)
+
+        for this measurement [2, 0] is added to the list _measurements_reg
+        for this measurement [0, 2] is added to the list _measurements_state, qubit 2 is located at position 0
+        in the resulting state array and can be indexed with [0]. classical 0 is located at position 2
+        in the resulting state array and can be indexed with [2].
+
+        :param experiment: The experiment with gate operations and header.
+
+        """
+        header = experiment.header
+        self._number_of_qubits = header.n_qubits
+        self._number_of_clbits = header.memory_slots
+
+        for instruction in experiment.instructions:
+            if instruction.name == 'measure':
+                self._measurements_reg.append([instruction.qubits[0], instruction.memory[0]])
+                self._measurements_state.append([self._number_of_qubits - 1 - instruction.qubits[0],
+                                                 self._number_of_clbits - 1 - instruction.memory[0]])
+
+        if not self._measurements_reg:
+            self._measurements_reg = [[index, index] for index in range(self._number_of_qubits)]
+            self._measurements_state = self._measurements_reg
+
+        # do some validations
+        self._validate_number_of_clbits()
+
+    @property
+    def max_measurement_index(self) -> int:
+        """
+        :return: Return the highest classical bit that is used as a storage for a qubit measurement
+        """
+        return max(measurement[1] for measurement in self._measurements_reg)
+
+    def get_qreg_for_conditional_creg(self, creg: int) -> int:
+        """
+        This method returns the qubit register that was measured to be stored in the classical register given
+
+            1. Try to find a measurement where the classical bit creg is used as storgae -> return the qubit index of
+            this measurement.
+            2. When no measurement is found for this classical bit, we assume the equivalent qubit (same index) is used
+            First check if a measurement is found for this qubit to another classical register, we raise an error.
+            This situation is not supported.
+
+        :param creg: The classical register.
+
+        :return: Returns the qubit index for the qubit that is measured to the classical register creg
+        """
+        for q1, c1 in self._measurements_reg:
+            if c1 == creg:
+                return q1
+
+        for q1, c1 in self._measurements_reg:
+            if q1 == creg:
+                raise QiskitBackendError(f"Classical bit {creg} used in a conditional gate is not measured "
+                                         f"and the equivalent qubit {q1} is measured to another classical bit {c1}")
+
+        return creg
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Translate the class instance to a (minimal) dictionary used for interpreting the results from the backend
+
+        :return:
+            Dict containing the measurement list with positional indexes in the resulting qubit_state and
+            classical_state and the number of classical bits.
+        """
+        return {'measurements_state': self._measurements_state,
+                'measurements_reg': self._measurements_reg,
+                'number_of_qubits': self._number_of_qubits,
+                'number_of_clbits': self._number_of_clbits}
+
+    def from_dict(self, measurement_input: Dict[str, Any]) -> None:
+        """
+        Translate the input dictionary to the class instance variables
+
+        :param measurement_input: A dictionary with the measurement information. See method to_dict
+        """
+        self._measurements_state = measurement_input['measurements_state']
+        self._measurements_reg = measurement_input['measurements_reg']
+        self._number_of_qubits = measurement_input['number_of_qubits']
+        self._number_of_clbits = measurement_input['number_of_clbits']
+
+    def _validate_number_of_clbits(self) -> None:
+        """ Validate the (number of) classical bits used in the measurements are valid for the algorithm
+
+        Checks whether the number of classical bits has a value cQASM can support.
+
+        1.  When number of classical bits is less than 1 an error is raised.
+        2.  When a classical bit is used in a  measurement with an index higher than the number of classical bits an
+            error is raised.
+        """
+        if self._number_of_clbits < 1:
+            raise QiskitBackendError(f"Invalid amount of classical bits ({self._number_of_clbits})!")
+
+        if self.max_measurement_index >= self._number_of_clbits:
+            raise QiskitBackendError(f"Number of classical bits ({self._number_of_clbits}) is not sufficient for "
+                                     f"storing the outcomes of the experiment")
+
+    def validate_unsupported_measurements(self) -> None:
+        """ Validate unsupported measurements (for not full state projection algorithms)
+
+        Certain measurements cannot be handled correctly because cQASM isn't as flexible as Qiskit in measuring to
+        specific classical bits. Therefore some Qiskit constructions are not supported in QI:
+
+            1. When a quantum register is measured to different classical registers
+            2. When a classical register is used for the measurement of more than one quantum register
+
+        :raises QiskitBackendError: When the circuit contains an invalid measurement
+        """
+        for q1, c1 in self._measurements_reg:
+            for q2, c2 in self._measurements_reg:
+                if q1 == q2 and c1 != c2:
+                    raise QiskitBackendError(f'Measurement of qubit {q1} to different classical registers is not '
+                                             f'supported')
+                if q1 != q2 and c1 == c2:
+                    raise QiskitBackendError(f'Measurement of different qubits to the same classical register {c1} '
+                                             f'is not supported')
+
+    def qubit_to_classical_hex(self, qubit_register: str) -> str:
+        """ This function converts the qubit register data to the hexadecimal representation of the classical state.
+
+        :param qubit_register: The measured value of the qubits represented as int.
+
+        :return:
+            The hexadecimal value of the classical state.
+        """
+        qubit_state = ('{0:0{1}b}'.format(int(qubit_register), self.nr_of_qubits))
+        classical_state = ['0'] * self.nr_of_clbits
+        for q, c in self._measurements_state:
+            classical_state[c] = qubit_state[q]
+        classical_state_str = ''.join(classical_state)
+        classical_state_hex = hex(int(classical_state_str, 2))
+        return classical_state_hex

--- a/src/tests/quantuminspire/qiskit/test_backend_qx.py
+++ b/src/tests/quantuminspire/qiskit/test_backend_qx.py
@@ -18,22 +18,21 @@ limitations under the License.
 
 import json
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, ANY
 
 import numpy as np
-import qiskit
-from coreapi.exceptions import ErrorMessage
 from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.compiler import assemble
 from qiskit.providers.models import QasmBackendConfiguration
 from qiskit.providers.models.backendconfiguration import GateConfig
-from qiskit.qobj import QasmQobjExperiment, QasmQobj
+from qiskit.qobj import QasmQobjExperiment
 
 from quantuminspire.api import QuantumInspireAPI
 from quantuminspire.exceptions import QiskitBackendError, ApiError
 from quantuminspire.qiskit.backend_qx import QuantumInspireBackend
 from quantuminspire.qiskit.qi_job import QIJob
 from quantuminspire.job import QuantumInspireJob
+from quantuminspire.qiskit.measurements import Measurements
 from quantuminspire.qiskit.quantum_inspire_provider import QuantumInspireProvider
 from quantuminspire.version import __version__ as quantum_inspire_version
 
@@ -46,7 +45,6 @@ def first_item(iterable):
 class TestQiSimulatorPy(unittest.TestCase):
 
     def setUp(self):
-        operations = []
         self._basic_job_dictionary = dict([('url', 'http://saevar-qutech-nginx/api/jobs/24/'),
                                            ('name', 'circuit0'),
                                            ('id', 24),
@@ -74,26 +72,6 @@ class TestQiSimulatorPy(unittest.TestCase):
         qobj = TestQiSimulatorPy._circuit_to_qobj(circuit)
         return qobj.experiments[0]
 
-    def test_collect_measurements(self):
-        qc = QuantumCircuit(2, 2)
-        qc.cx(0, 1)
-        qc.measure(0, 1)
-        qc.measure(1, 0)
-
-        experiment = self._circuit_to_experiment(qc)
-
-        measurements = QuantumInspireBackend._collect_measurements(experiment)
-        self.assertDictEqual(measurements, {'measurements': [[1, 0], [0, 1]], 'number_of_clbits': 2})
-
-    def test_collect_measurements_without_measurements(self):
-        qc = QuantumCircuit(2, 2)
-        qc.cx(0, 1)
-
-        experiment = self._circuit_to_experiment(qc)
-
-        measurements = QuantumInspireBackend._collect_measurements(experiment)
-        self.assertDictEqual(measurements, {'measurements': [[0, 0], [1, 1]], 'number_of_clbits': 2})
-
     def test_backend_name(self):
         simulator = QuantumInspireBackend(Mock(), Mock())
         name = simulator.backend_name
@@ -106,8 +84,8 @@ class TestQiSimulatorPy(unittest.TestCase):
             backend_name='qi_simulator',
             backend_version=quantum_inspire_version,
             n_qubits=26,
-            basis_gates=['x', 'y', 'z', 'h', 'rx', 'ry', 'rz', 's', 'sdg', 't', 'tdg', 'cx', 'ccx', 'u1', 'u2', 'u3',
-                         'id', 'swap', 'cz', 'snapshot'],
+            basis_gates=['x', 'y', 'z', 'h', 'rx', 'ry', 'rz', 's', 'sdg', 't', 'tdg', 'cx', 'ccx', 'u1', 'p', 'u2',
+                         'u3', 'id', 'swap', 'cz', 'snapshot'],
             gates=[GateConfig(name='NotUsed', parameters=['NaN'], qasm_def='NaN')],
             conditional=True,
             simulator=True,
@@ -177,9 +155,10 @@ class TestQiSimulatorPy(unittest.TestCase):
                                                 'raw_data_url': 'http://saevar-qutech-nginx/api/results/24/raw-data/'}
         api.get_raw_data_from_result.return_value = [1] * 60 + [3] * 40
         jobs = self._basic_job_dictionary
-        measurements = QuantumInspireBackend._collect_measurements(experiment)
+        measurements = Measurements()
+        measurements.collect_measurements(experiment)
         user_data = {'name': 'name', 'memory_slots': 2,
-                     'creg_sizes': [['c1', 2]], 'measurements': measurements}
+                     'creg_sizes': [['c1', 2]], 'measurements': measurements.to_dict()}
         jobs['user_data'] = json.dumps(user_data)
         api.get_jobs_from_project.return_value = [jobs]
         job = QIJob('backend', '42', api)
@@ -211,9 +190,10 @@ class TestQiSimulatorPy(unittest.TestCase):
                                                 'raw_data_url': 'http://saevar-qutech-nginx/api/results/24/raw-data/'}
         api.get_raw_data_from_result.return_value = [1] * 60 + [3] * 40
         job = self._basic_job_dictionary
-        measurements = QuantumInspireBackend._collect_measurements(experiment)
+        measurements = Measurements()
+        measurements.collect_measurements(experiment)
         user_data = {'name': 'name', 'memory_slots': 2,
-                     'creg_sizes': [['c1', 2]], 'measurements': measurements}
+                     'creg_sizes': [['c1', 2]], 'measurements': measurements.to_dict()}
         job['user_data'] = json.dumps(user_data)
 
         api.get_job.side_effect = [job]
@@ -301,9 +281,10 @@ class TestQiSimulatorPy(unittest.TestCase):
         api.get_raw_data_from_result.return_value = []
         api.get_backend_type_by_name.return_value = {'max_number_of_shots': 4096}
         jobs = self._basic_job_dictionary
-        measurements = QuantumInspireBackend._collect_measurements(experiment)
+        measurements = Measurements()
+        measurements.collect_measurements(experiment)
         user_data = {'name': 'name', 'memory_slots': 2,
-                     'creg_sizes': [['c1', 2]], 'measurements': measurements}
+                     'creg_sizes': [['c1', 2]], 'measurements': measurements.to_dict()}
         jobs['user_data'] = json.dumps(user_data)
         api.get_jobs_from_project.return_value = [jobs]
         job = QIJob('backend', '42', api)
@@ -344,9 +325,10 @@ class TestQiSimulatorPy(unittest.TestCase):
                                                         'http://saevar-qutech-nginx/api/results/24/raw-data/'}
             api.get_raw_data_from_result.return_value = []
             jobs = self._basic_job_dictionary
-            measurements = QuantumInspireBackend._collect_measurements(experiment)
+            measurements = Measurements()
+            measurements.collect_measurements(experiment)
             user_data = {'name': 'name', 'memory_slots': 2,
-                         'creg_sizes': [['c1', 2]], 'measurements': measurements}
+                         'creg_sizes': [['c1', 2]], 'measurements': measurements.to_dict()}
             jobs['user_data'] = json.dumps(user_data)
             api.get_jobs_from_project.return_value = [jobs]
             job = QIJob('backend', '42', api)
@@ -413,22 +395,6 @@ class TestQiSimulatorPy(unittest.TestCase):
                                                    ' number of qubits when using conditional gate operations',
                                simulator.run, qc)
 
-    def test_validate_nr_classical_qubits_less_than_needed_for_storing_measured_qubits(self):
-        api = Mock()
-        api.create_project.return_value = {'id': 42}
-        api.execute_qasm_async.return_value = 42
-        api.get_backend_type_by_name.return_value = {'max_number_of_shots': 4096}
-        simulator = QuantumInspireBackend(api, Mock())
-
-        q = QuantumRegister(2, "q")
-        c = ClassicalRegister(1, "c")
-        qc = QuantumCircuit(q, c, name="conditional")
-        qc.cx(q[0], q[1])
-
-        self.assertRaisesRegex(QiskitBackendError, 'Number of classical bits \(1\) is not sufficient for storing the '
-                                                   'outcomes of the experiment',
-                               simulator.run, qc)
-
     def test_for_non_fsp_gate_after_measurement(self):
         with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()) as result_experiment:
             api = Mock()
@@ -445,7 +411,10 @@ class TestQiSimulatorPy(unittest.TestCase):
 
             simulator.run(qc, 25)
             experiment = self._circuit_to_experiment(qc)
-        result_experiment.assert_called_once_with(experiment, 25, project=project, full_state_projection=False)
+
+            measurements = Mock()
+        result_experiment.assert_called_once_with(experiment, 25, ANY, project=project,
+                                                  full_state_projection=False)
 
     def test_for_non_fsp_measurements_at_begin_and_end(self):
         with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()) as result_experiment:
@@ -464,7 +433,8 @@ class TestQiSimulatorPy(unittest.TestCase):
 
             simulator.run(qc, 25)
             experiment = self._circuit_to_experiment(qc)
-        result_experiment.assert_called_once_with(experiment, 25, project=project, full_state_projection=False)
+        result_experiment.assert_called_once_with(experiment, 25, ANY, project=project,
+                                                  full_state_projection=False)
 
     def test_for_fsp_measurements_at_end_only(self):
         with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()) as result_experiment:
@@ -482,7 +452,8 @@ class TestQiSimulatorPy(unittest.TestCase):
 
             simulator.run(qc, 25)
             experiment = self._circuit_to_experiment(qc)
-        result_experiment.assert_called_once_with(experiment, 25, project=project, full_state_projection=True)
+        result_experiment.assert_called_once_with(experiment, 25, ANY, project=project,
+                                                  full_state_projection=True)
 
     def test_for_fsp_no_measurements(self):
         with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()) as result_experiment:
@@ -499,7 +470,8 @@ class TestQiSimulatorPy(unittest.TestCase):
 
             simulator.run(qc, 25)
             experiment = self._circuit_to_experiment(qc)
-        result_experiment.assert_called_once_with(experiment, 25, project=project, full_state_projection=True)
+        result_experiment.assert_called_once_with(experiment, 25, ANY, project=project,
+                                                  full_state_projection=True)
 
     def test_for_non_fsp_hardware_backend(self):
         with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()) as result_experiment:
@@ -519,44 +491,8 @@ class TestQiSimulatorPy(unittest.TestCase):
 
             simulator.run(qc, 25)
             experiment = self._circuit_to_experiment(qc)
-        result_experiment.assert_called_once_with(experiment, 25, project=project, full_state_projection=False)
-
-    def test_measurement_2_qubits_to_1_classical_bit(self):
-        with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()):
-            api = Mock()
-            project = {'id': 42}
-            api.create_project.return_value = project
-            api.execute_qasm_async.return_value = 42
-            api.get_backend_type_by_name.return_value = {'max_number_of_shots': 4096}
-            simulator = QuantumInspireBackend(api, Mock())
-
-            qc = QuantumCircuit(2, 2)
-            qc.cx(0, 1)
-            qc.measure(0, 0)
-            qc.x(0)
-            qc.measure(1, 0)
-
-            self.assertRaisesRegex(QiskitBackendError, 'Measurement of different qubits to the same classical '
-                                                       'register 0 is not supported', simulator.run, qc)
-
-    def test_measurement_1_qubit_to_2_classical_bits(self):
-        with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()):
-            api = Mock()
-            project = {'id': 42}
-            api.create_project.return_value = project
-            api.execute_qasm_async.return_value = 42
-            api.get_backend_type_by_name.return_value = {'max_number_of_shots': 4096}
-            simulator = QuantumInspireBackend(api, Mock())
-
-            qc = QuantumCircuit(2, 2)
-            qc.cx(0, 1)
-            qc.measure(1, 1)
-            qc.measure(0, 0)
-            qc.x(0)
-            qc.measure(1, 0)
-
-            self.assertRaisesRegex(QiskitBackendError, 'Measurement of qubit 1 to different classical registers '
-                                                       'is not supported', simulator.run, qc)
+        result_experiment.assert_called_once_with(experiment, 25, ANY, project=project,
+                                                  full_state_projection=False)
 
     def test_valid_non_fsp_measurement_qubit_to_classical(self):
         api = Mock()
@@ -650,9 +586,10 @@ class TestQiSimulatorPyHistogram(unittest.TestCase):
                            expected_histogram_prob, expected_memory):
         self.mock_api.set(mock_result1, mock_result2)
         jobs = self._basic_job_dictionary
-        measurements = QuantumInspireBackend._collect_measurements(QasmQobjExperiment.from_dict(single_experiment))
+        measurements = Measurements()
+        measurements.collect_measurements(QasmQobjExperiment.from_dict(single_experiment))
         user_data = {'name': 'name', 'memory_slots': 2,
-                     'creg_sizes': [['c1', 2]], 'measurements': measurements}
+                     'creg_sizes': [['c1', 2]], 'measurements': measurements.to_dict()}
         jobs['user_data'] = json.dumps(user_data)
         self.mock_api.get_jobs_from_project.return_value = [jobs]
         job = QIJob('backend', '42', self.mock_api)

--- a/src/tests/quantuminspire/qiskit/test_backend_qx.py
+++ b/src/tests/quantuminspire/qiskit/test_backend_qx.py
@@ -155,8 +155,7 @@ class TestQiSimulatorPy(unittest.TestCase):
                                                 'raw_data_url': 'http://saevar-qutech-nginx/api/results/24/raw-data/'}
         api.get_raw_data_from_result.return_value = [1] * 60 + [3] * 40
         jobs = self._basic_job_dictionary
-        measurements = Measurements()
-        measurements.collect_measurements(experiment)
+        measurements = Measurements.from_experiment(experiment)
         user_data = {'name': 'name', 'memory_slots': 2,
                      'creg_sizes': [['c1', 2]], 'measurements': measurements.to_dict()}
         jobs['user_data'] = json.dumps(user_data)
@@ -190,8 +189,7 @@ class TestQiSimulatorPy(unittest.TestCase):
                                                 'raw_data_url': 'http://saevar-qutech-nginx/api/results/24/raw-data/'}
         api.get_raw_data_from_result.return_value = [1] * 60 + [3] * 40
         job = self._basic_job_dictionary
-        measurements = Measurements()
-        measurements.collect_measurements(experiment)
+        measurements = Measurements.from_experiment(experiment)
         user_data = {'name': 'name', 'memory_slots': 2,
                      'creg_sizes': [['c1', 2]], 'measurements': measurements.to_dict()}
         job['user_data'] = json.dumps(user_data)
@@ -258,7 +256,7 @@ class TestQiSimulatorPy(unittest.TestCase):
 
         qobj = self._circuit_to_qobj(qc)
         qobj.experiments[0].header.memory_slots = 0
-        self.assertRaisesRegex(QiskitBackendError, 'Invalid amount of classical bits \(0\)!',
+        self.assertRaisesRegex(QiskitBackendError, 'Invalid number of classical bits \(0\)!',
                                simulator.run, qobj)
         api.delete_project.assert_called_with(default_project_number)
 
@@ -281,8 +279,7 @@ class TestQiSimulatorPy(unittest.TestCase):
         api.get_raw_data_from_result.return_value = []
         api.get_backend_type_by_name.return_value = {'max_number_of_shots': 4096}
         jobs = self._basic_job_dictionary
-        measurements = Measurements()
-        measurements.collect_measurements(experiment)
+        measurements = Measurements.from_experiment(experiment)
         user_data = {'name': 'name', 'memory_slots': 2,
                      'creg_sizes': [['c1', 2]], 'measurements': measurements.to_dict()}
         jobs['user_data'] = json.dumps(user_data)
@@ -325,8 +322,7 @@ class TestQiSimulatorPy(unittest.TestCase):
                                                         'http://saevar-qutech-nginx/api/results/24/raw-data/'}
             api.get_raw_data_from_result.return_value = []
             jobs = self._basic_job_dictionary
-            measurements = Measurements()
-            measurements.collect_measurements(experiment)
+            measurements = Measurements.from_experiment(experiment)
             user_data = {'name': 'name', 'memory_slots': 2,
                          'creg_sizes': [['c1', 2]], 'measurements': measurements.to_dict()}
             jobs['user_data'] = json.dumps(user_data)
@@ -376,7 +372,7 @@ class TestQiSimulatorPy(unittest.TestCase):
 
         job = self._circuit_to_qobj(qc)
         job.experiments[0].header.memory_slots = 0
-        self.assertRaisesRegex(QiskitBackendError, 'Invalid amount of classical bits \(0\)!',
+        self.assertRaisesRegex(QiskitBackendError, 'Invalid number of classical bits \(0\)!',
                                simulator.run, job)
 
     def test_validate_nr_classical_qubits_less_than_nr_qubits_conditional_gate(self):
@@ -412,7 +408,6 @@ class TestQiSimulatorPy(unittest.TestCase):
             simulator.run(qc, 25)
             experiment = self._circuit_to_experiment(qc)
 
-            measurements = Mock()
         result_experiment.assert_called_once_with(experiment, 25, ANY, project=project,
                                                   full_state_projection=False)
 
@@ -586,8 +581,7 @@ class TestQiSimulatorPyHistogram(unittest.TestCase):
                            expected_histogram_prob, expected_memory):
         self.mock_api.set(mock_result1, mock_result2)
         jobs = self._basic_job_dictionary
-        measurements = Measurements()
-        measurements.collect_measurements(QasmQobjExperiment.from_dict(single_experiment))
+        measurements = Measurements.from_experiment(QasmQobjExperiment.from_dict(single_experiment))
         user_data = {'name': 'name', 'memory_slots': 2,
                      'creg_sizes': [['c1', 2]], 'measurements': measurements.to_dict()}
         jobs['user_data'] = json.dumps(user_data)

--- a/src/tests/quantuminspire/qiskit/test_circuit_parser.py
+++ b/src/tests/quantuminspire/qiskit/test_circuit_parser.py
@@ -36,8 +36,7 @@ class TestQiCircuitToString(unittest.TestCase):
         backend = QuantumInspireBackend(Mock(), Mock())
         qobj = assemble(circuit, backend, **run_config_dict)
         experiment = qobj.experiments[0]
-        measurements = Measurements()
-        measurements.collect_measurements(experiment)
+        measurements = Measurements.from_experiment(experiment)
         simulator = QuantumInspireBackend(Mock(), Mock())
         result = simulator._generate_cqasm(experiment, measurements, full_state_projection)
         return result
@@ -59,8 +58,7 @@ class TestQiCircuitToString(unittest.TestCase):
                 qiskit_instruction = Instruction('dummy', 0, 0, instruction.params)
                 instruction.params = qiskit_instruction.params
 
-        measurements = Measurements()
-        measurements.collect_measurements(experiment)
+        measurements = Measurements.from_experiment(experiment)
         simulator = QuantumInspireBackend(Mock(), Mock())
         result = simulator._generate_cqasm(experiment, measurements, full_state_projection)
         return result

--- a/src/tests/quantuminspire/qiskit/test_measurements.py
+++ b/src/tests/quantuminspire/qiskit/test_measurements.py
@@ -1,0 +1,220 @@
+""" Quantum Inspire SDK
+
+Copyright 2018 QuTech Delft
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+import unittest
+from unittest.mock import Mock
+
+from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.compiler import assemble
+from quantuminspire.qiskit.backend_qx import QuantumInspireBackend
+from quantuminspire.exceptions import QiskitBackendError
+from quantuminspire.qiskit.measurements import Measurements
+
+
+class TestMeasurements(unittest.TestCase):
+
+    def setUp(self):
+        self.measurements = Measurements()
+
+    @staticmethod
+    def _circuit_to_qobj(circuit):
+        run_config_dict = {'shots': 25, 'memory': True}
+        backend = QuantumInspireBackend(Mock(), Mock())
+        qobj = assemble(circuit, backend, **run_config_dict)
+        return qobj
+
+    @staticmethod
+    def _circuit_to_experiment(circuit):
+        qobj = TestMeasurements._circuit_to_qobj(circuit)
+        return qobj.experiments[0]
+
+    def test_collect_measurements(self):
+        qc = QuantumCircuit(2, 2)
+        qc.cx(0, 1)
+        qc.measure(0, 1)
+        qc.measure(1, 0)
+
+        experiment = self._circuit_to_experiment(qc)
+        self.measurements.collect_measurements(experiment)
+        expected_result = {'measurements_state': [[1, 0], [0, 1]],
+                           'measurements_reg': [[0, 1], [1, 0]],
+                           'number_of_qubits': 2,
+                           'number_of_clbits': 2
+                           }
+        self.assertDictEqual(self.measurements.to_dict(), expected_result)
+        self.assertEqual(self.measurements.nr_of_qubits, 2)
+        self.assertEqual(self.measurements.nr_of_clbits, 2)
+
+    def test_collect_measurements_without_measurements(self):
+        qc = QuantumCircuit(2, 2)
+        qc.cx(0, 1)
+
+        experiment = self._circuit_to_experiment(qc)
+
+        self.measurements.collect_measurements(experiment)
+        expected_result = {'measurements_state': [[0, 0], [1, 1]],
+                           'measurements_reg': [[0, 0], [1, 1]],
+                           'number_of_qubits': 2,
+                           'number_of_clbits': 2
+                           }
+        self.assertDictEqual(self.measurements.to_dict(), expected_result)
+        self.assertEqual(self.measurements.nr_of_qubits, 2)
+        self.assertEqual(self.measurements.nr_of_clbits, 2)
+
+    def test_validate_nr_classical_qubits_less_than_needed_for_storing_measured_qubits(self):
+        q = QuantumRegister(2, "q")
+        c = ClassicalRegister(1, "c")
+        qc = QuantumCircuit(q, c, name="conditional")
+        qc.cx(q[0], q[1])
+
+        experiment = self._circuit_to_experiment(qc)
+        self.assertRaisesRegex(QiskitBackendError, 'Number of classical bits \(1\) is not sufficient for storing the '
+                                                   'outcomes of the experiment',
+                               self.measurements.collect_measurements, experiment)
+
+    def test_invalid_amount_of_classical_bits(self):
+        qc = QuantumCircuit(2, 2)
+        qc.measure(1, 0)
+
+        qobj = self._circuit_to_qobj(qc)
+        qobj.experiments[0].header.memory_slots = 0
+
+        experiment = qobj.experiments[0]
+        self.assertRaisesRegex(QiskitBackendError, 'Invalid amount of classical bits \(0\)!',
+                               self.measurements.collect_measurements, experiment)
+
+    def test_max_measurement_index(self):
+        qr = QuantumRegister(5)
+        cr = ClassicalRegister(3)
+        cr_ghz = ClassicalRegister(2)
+        circuit = QuantumCircuit(qr, cr, cr_ghz)
+
+        circuit.measure(2, 3)
+        circuit.measure(3, 4)
+        circuit.measure([0, 1, 4], cr)
+        circuit.measure([2, 3], cr_ghz)
+
+        experiment = self._circuit_to_experiment(circuit)
+        self.measurements.collect_measurements(experiment)
+
+        self.assertEqual(self.measurements.max_measurement_index, 4)
+
+    def test_max_measurement_index_less_than_nr_of_clbits(self):
+        qr = QuantumRegister(5)
+        cr = ClassicalRegister(3)
+        cr_ghz = ClassicalRegister(2)
+        circuit = QuantumCircuit(qr, cr, cr_ghz)
+
+        circuit.measure(2, 3)
+        circuit.measure([0, 1, 4], cr)
+        circuit.measure([2], cr_ghz[0])
+
+        experiment = self._circuit_to_experiment(circuit)
+        self.measurements.collect_measurements(experiment)
+
+        self.assertEqual(self.measurements.max_measurement_index, 3)
+
+    def test_get_qreg_for_conditional_creg(self):
+        qr = QuantumRegister(5)
+        cr = ClassicalRegister(3)
+        cr_ghz = ClassicalRegister(2)
+        circuit = QuantumCircuit(qr, cr, cr_ghz)
+
+        circuit.measure(2, 3)
+        circuit.measure([1, 4], [1, 2])
+        circuit.measure([2], cr_ghz[0])
+
+        experiment = self._circuit_to_experiment(circuit)
+        self.measurements.collect_measurements(experiment)
+
+        self.assertEqual(self.measurements.get_qreg_for_conditional_creg(3), 2)
+        self.assertEqual(self.measurements.get_qreg_for_conditional_creg(1), 1)
+        self.assertEqual(self.measurements.get_qreg_for_conditional_creg(2), 4)
+        self.assertEqual(self.measurements.get_qreg_for_conditional_creg(0), 0)
+        self.assertRaisesRegex(QiskitBackendError, "Classical bit 4 used in a conditional gate is not measured and the "
+                                                   "equivalent qubit 4 is measured to another classical bit 2",
+                               self.measurements.get_qreg_for_conditional_creg, 4)
+
+    def test_from_dict(self):
+        input = {'measurements_state': [[0, 0], [1, 1]],
+                 'measurements_reg': [[0, 0], [1, 1]],
+                 'number_of_qubits': 2,
+                 'number_of_clbits': 2
+                 }
+        new_measurements = Measurements()
+        new_measurements.from_dict(input)
+
+        self.assertEqual(new_measurements.nr_of_qubits, 2)
+        self.assertEqual(new_measurements.nr_of_clbits, 2)
+        self.assertDictEqual(new_measurements.to_dict(), input)
+
+    def test_measurement_2_qubits_to_1_classical_bit(self):
+        qc = QuantumCircuit(2, 2)
+        qc.cx(0, 1)
+        qc.measure(0, 0)
+        qc.x(0)
+        qc.measure(1, 0)
+
+        experiment = self._circuit_to_experiment(qc)
+        self.measurements.collect_measurements(experiment)
+
+        self.assertRaisesRegex(QiskitBackendError, 'Measurement of different qubits to the same classical '
+                                                   'register 0 is not supported',
+                               self.measurements.validate_unsupported_measurements)
+
+    def test_measurement_1_qubit_to_2_classical_bits(self):
+        qc = QuantumCircuit(2, 2)
+        qc.cx(0, 1)
+        qc.measure(1, 1)
+        qc.measure(0, 0)
+        qc.x(0)
+        qc.measure(1, 0)
+
+        experiment = self._circuit_to_experiment(qc)
+        self.measurements.collect_measurements(experiment)
+
+        self.assertRaisesRegex(QiskitBackendError, 'Measurement of qubit 1 to different classical registers '
+                                                   'is not supported',
+                               self.measurements.validate_unsupported_measurements)
+
+    def test_qubit_to_classical_hex(self):
+        qc = QuantumCircuit(4, 4)
+        qc.measure(0, 0)
+        qc.measure(1, 1)
+        qc.measure(2, 2)
+        qc.measure(3, 3)
+
+        experiment = self._circuit_to_experiment(qc)
+        self.measurements.collect_measurements(experiment)
+
+        self.assertEqual(self.measurements.qubit_to_classical_hex('3'), '0x3')
+        self.assertEqual(self.measurements.qubit_to_classical_hex('7'), '0x7')
+        self.assertEqual(self.measurements.qubit_to_classical_hex('10'), '0xa')
+
+    def test_qubit_to_classical_hex_reversed(self):
+        qc = QuantumCircuit(4, 4)
+        qc.measure(0, 3)
+        qc.measure(1, 2)
+        qc.measure(2, 1)
+        qc.measure(3, 0)
+
+        experiment = self._circuit_to_experiment(qc)
+        self.measurements.collect_measurements(experiment)
+
+        self.assertEqual(self.measurements.qubit_to_classical_hex('3'), '0xc')
+        self.assertEqual(self.measurements.qubit_to_classical_hex('7'), '0xe')
+        self.assertEqual(self.measurements.qubit_to_classical_hex('10'), '0x5')

--- a/src/tests/quantuminspire/qiskit/test_measurements.py
+++ b/src/tests/quantuminspire/qiskit/test_measurements.py
@@ -27,9 +27,6 @@ from quantuminspire.qiskit.measurements import Measurements
 
 class TestMeasurements(unittest.TestCase):
 
-    def setUp(self):
-        self.measurements = Measurements()
-
     @staticmethod
     def _circuit_to_qobj(circuit):
         run_config_dict = {'shots': 25, 'memory': True}
@@ -42,22 +39,22 @@ class TestMeasurements(unittest.TestCase):
         qobj = TestMeasurements._circuit_to_qobj(circuit)
         return qobj.experiments[0]
 
-    def test_collect_measurements(self):
+    def test_from_experiment(self):
         qc = QuantumCircuit(2, 2)
         qc.cx(0, 1)
         qc.measure(0, 1)
         qc.measure(1, 0)
 
         experiment = self._circuit_to_experiment(qc)
-        self.measurements.collect_measurements(experiment)
+        measurements = Measurements.from_experiment(experiment)
         expected_result = {'measurements_state': [[1, 0], [0, 1]],
                            'measurements_reg': [[0, 1], [1, 0]],
                            'number_of_qubits': 2,
                            'number_of_clbits': 2
                            }
-        self.assertDictEqual(self.measurements.to_dict(), expected_result)
-        self.assertEqual(self.measurements.nr_of_qubits, 2)
-        self.assertEqual(self.measurements.nr_of_clbits, 2)
+        self.assertDictEqual(measurements.to_dict(), expected_result)
+        self.assertEqual(measurements.nr_of_qubits, 2)
+        self.assertEqual(measurements.nr_of_clbits, 2)
 
     def test_collect_measurements_without_measurements(self):
         qc = QuantumCircuit(2, 2)
@@ -65,28 +62,28 @@ class TestMeasurements(unittest.TestCase):
 
         experiment = self._circuit_to_experiment(qc)
 
-        self.measurements.collect_measurements(experiment)
+        measurements = Measurements.from_experiment(experiment)
         expected_result = {'measurements_state': [[0, 0], [1, 1]],
                            'measurements_reg': [[0, 0], [1, 1]],
                            'number_of_qubits': 2,
                            'number_of_clbits': 2
                            }
-        self.assertDictEqual(self.measurements.to_dict(), expected_result)
-        self.assertEqual(self.measurements.nr_of_qubits, 2)
-        self.assertEqual(self.measurements.nr_of_clbits, 2)
+        self.assertDictEqual(measurements.to_dict(), expected_result)
+        self.assertEqual(measurements.nr_of_qubits, 2)
+        self.assertEqual(measurements.nr_of_clbits, 2)
 
     def test_validate_nr_classical_qubits_less_than_needed_for_storing_measured_qubits(self):
-        q = QuantumRegister(2, "q")
-        c = ClassicalRegister(1, "c")
-        qc = QuantumCircuit(q, c, name="conditional")
+        q = QuantumRegister(2, 'q')
+        c = ClassicalRegister(1, 'c')
+        qc = QuantumCircuit(q, c, name='conditional')
         qc.cx(q[0], q[1])
 
         experiment = self._circuit_to_experiment(qc)
         self.assertRaisesRegex(QiskitBackendError, 'Number of classical bits \(1\) is not sufficient for storing the '
                                                    'outcomes of the experiment',
-                               self.measurements.collect_measurements, experiment)
+                               Measurements.from_experiment, experiment)
 
-    def test_invalid_amount_of_classical_bits(self):
+    def test_invalid_number_of_classical_bits(self):
         qc = QuantumCircuit(2, 2)
         qc.measure(1, 0)
 
@@ -94,8 +91,8 @@ class TestMeasurements(unittest.TestCase):
         qobj.experiments[0].header.memory_slots = 0
 
         experiment = qobj.experiments[0]
-        self.assertRaisesRegex(QiskitBackendError, 'Invalid amount of classical bits \(0\)!',
-                               self.measurements.collect_measurements, experiment)
+        self.assertRaisesRegex(QiskitBackendError, 'Invalid number of classical bits \(0\)!',
+                               Measurements.from_experiment, experiment)
 
     def test_max_measurement_index(self):
         qr = QuantumRegister(5)
@@ -109,9 +106,10 @@ class TestMeasurements(unittest.TestCase):
         circuit.measure([2, 3], cr_ghz)
 
         experiment = self._circuit_to_experiment(circuit)
-        self.measurements.collect_measurements(experiment)
 
-        self.assertEqual(self.measurements.max_measurement_index, 4)
+        measurements = Measurements.from_experiment(experiment)
+
+        self.assertEqual(measurements.max_measurement_index, 4)
 
     def test_max_measurement_index_less_than_nr_of_clbits(self):
         qr = QuantumRegister(5)
@@ -124,9 +122,9 @@ class TestMeasurements(unittest.TestCase):
         circuit.measure([2], cr_ghz[0])
 
         experiment = self._circuit_to_experiment(circuit)
-        self.measurements.collect_measurements(experiment)
+        measurements = Measurements.from_experiment(experiment)
 
-        self.assertEqual(self.measurements.max_measurement_index, 3)
+        self.assertEqual(measurements.max_measurement_index, 3)
 
     def test_get_qreg_for_conditional_creg(self):
         qr = QuantumRegister(5)
@@ -139,15 +137,15 @@ class TestMeasurements(unittest.TestCase):
         circuit.measure([2], cr_ghz[0])
 
         experiment = self._circuit_to_experiment(circuit)
-        self.measurements.collect_measurements(experiment)
+        measurements = Measurements.from_experiment(experiment)
 
-        self.assertEqual(self.measurements.get_qreg_for_conditional_creg(3), 2)
-        self.assertEqual(self.measurements.get_qreg_for_conditional_creg(1), 1)
-        self.assertEqual(self.measurements.get_qreg_for_conditional_creg(2), 4)
-        self.assertEqual(self.measurements.get_qreg_for_conditional_creg(0), 0)
-        self.assertRaisesRegex(QiskitBackendError, "Classical bit 4 used in a conditional gate is not measured and the "
-                                                   "equivalent qubit 4 is measured to another classical bit 2",
-                               self.measurements.get_qreg_for_conditional_creg, 4)
+        self.assertEqual(measurements.get_qreg_for_conditional_creg(3), 2)
+        self.assertEqual(measurements.get_qreg_for_conditional_creg(1), 1)
+        self.assertEqual(measurements.get_qreg_for_conditional_creg(2), 4)
+        self.assertEqual(measurements.get_qreg_for_conditional_creg(0), 0)
+        self.assertRaisesRegex(QiskitBackendError, 'Classical bit 4 used in a conditional gate is not measured and the '
+                                                   'equivalent qubit 4 is measured to another classical bit 2',
+                               measurements.get_qreg_for_conditional_creg, 4)
 
     def test_from_dict(self):
         input = {'measurements_state': [[0, 0], [1, 1]],
@@ -155,12 +153,11 @@ class TestMeasurements(unittest.TestCase):
                  'number_of_qubits': 2,
                  'number_of_clbits': 2
                  }
-        new_measurements = Measurements()
-        new_measurements.from_dict(input)
+        measurements = Measurements.from_dict(input)
 
-        self.assertEqual(new_measurements.nr_of_qubits, 2)
-        self.assertEqual(new_measurements.nr_of_clbits, 2)
-        self.assertDictEqual(new_measurements.to_dict(), input)
+        self.assertEqual(measurements.nr_of_qubits, 2)
+        self.assertEqual(measurements.nr_of_clbits, 2)
+        self.assertDictEqual(measurements.to_dict(), input)
 
     def test_measurement_2_qubits_to_1_classical_bit(self):
         qc = QuantumCircuit(2, 2)
@@ -170,11 +167,11 @@ class TestMeasurements(unittest.TestCase):
         qc.measure(1, 0)
 
         experiment = self._circuit_to_experiment(qc)
-        self.measurements.collect_measurements(experiment)
+        measurements = Measurements.from_experiment(experiment)
 
         self.assertRaisesRegex(QiskitBackendError, 'Measurement of different qubits to the same classical '
                                                    'register 0 is not supported',
-                               self.measurements.validate_unsupported_measurements)
+                               measurements.validate_unsupported_measurements)
 
     def test_measurement_1_qubit_to_2_classical_bits(self):
         qc = QuantumCircuit(2, 2)
@@ -185,11 +182,11 @@ class TestMeasurements(unittest.TestCase):
         qc.measure(1, 0)
 
         experiment = self._circuit_to_experiment(qc)
-        self.measurements.collect_measurements(experiment)
+        measurements = Measurements.from_experiment(experiment)
 
         self.assertRaisesRegex(QiskitBackendError, 'Measurement of qubit 1 to different classical registers '
                                                    'is not supported',
-                               self.measurements.validate_unsupported_measurements)
+                               measurements.validate_unsupported_measurements)
 
     def test_qubit_to_classical_hex(self):
         qc = QuantumCircuit(4, 4)
@@ -199,11 +196,11 @@ class TestMeasurements(unittest.TestCase):
         qc.measure(3, 3)
 
         experiment = self._circuit_to_experiment(qc)
-        self.measurements.collect_measurements(experiment)
+        measurements = Measurements.from_experiment(experiment)
 
-        self.assertEqual(self.measurements.qubit_to_classical_hex('3'), '0x3')
-        self.assertEqual(self.measurements.qubit_to_classical_hex('7'), '0x7')
-        self.assertEqual(self.measurements.qubit_to_classical_hex('10'), '0xa')
+        self.assertEqual(measurements.qubit_to_classical_hex('3'), '0x3')
+        self.assertEqual(measurements.qubit_to_classical_hex('7'), '0x7')
+        self.assertEqual(measurements.qubit_to_classical_hex('10'), '0xa')
 
     def test_qubit_to_classical_hex_reversed(self):
         qc = QuantumCircuit(4, 4)
@@ -213,8 +210,8 @@ class TestMeasurements(unittest.TestCase):
         qc.measure(3, 0)
 
         experiment = self._circuit_to_experiment(qc)
-        self.measurements.collect_measurements(experiment)
+        measurements = Measurements.from_experiment(experiment)
 
-        self.assertEqual(self.measurements.qubit_to_classical_hex('3'), '0xc')
-        self.assertEqual(self.measurements.qubit_to_classical_hex('7'), '0xe')
-        self.assertEqual(self.measurements.qubit_to_classical_hex('10'), '0x5')
+        self.assertEqual(measurements.qubit_to_classical_hex('3'), '0xc')
+        self.assertEqual(measurements.qubit_to_classical_hex('7'), '0xe')
+        self.assertEqual(measurements.qubit_to_classical_hex('10'), '0x5')

--- a/src/tests/quantuminspire/qiskit/test_quantum_inspire_provider.py
+++ b/src/tests/quantuminspire/qiskit/test_quantum_inspire_provider.py
@@ -102,7 +102,7 @@ class TestQuantumInspireProvider(unittest.TestCase):
             self.assertEqual(3, backend.configuration().max_experiments)
             self.assertTrue(backend.configuration().conditional)
             self.assertEqual(backend.configuration().basis_gates, ['x', 'y', 'z', 'h', 'rx', 'ry', 'rz', 's', 'sdg',
-                                                                   't', 'tdg', 'cx', 'ccx', 'u1', 'u2', 'u3', 'id',
+                                                                   't', 'tdg', 'cx', 'ccx', 'u1', 'p', 'u2', 'u3', 'id',
                                                                    'swap', 'cz', 'snapshot'])
 
     def test_hardware_backend(self):


### PR DESCRIPTION
* Fixes https://github.com/QuTech-Delft/quantuminspire/issues/134
* Refactored measurement to a separate class and added measurement functionality to this class
* The fix itself is mainly situated in the call to measurements.get_qreg_for_conditional_creg in circuit_parser._parse_bin_ctrl_gate
* Added/adjusted unit tests