### PR TITLE
[SDS-794] Check for raw data list was wrong

### DIFF
--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -536,8 +536,7 @@ class QuantumInspireBackend(Backend):  # type: ignore
         converts this list of single shot values to hexadecimal memory data according the Qiskit spec.
         From this memory data the counts histogram is constructed by counting the single shot values.
 
-        :param result: The result output from the Quantum Inspire backend with full-
-                       state projection histogram output.
+        :param result: The result output from the Quantum Inspire backend with full state projection histogram output.
         :param measurements: The measurement instance containing measurement information and measurement functionality.
         :param raw_data_list: The raw data from the result for this experiment.
 
@@ -578,8 +577,7 @@ class QuantumInspireBackend(Backend):  # type: ignore
         When shots = 1, the backend returns an empty list as raw_data. This is a special case handled in method
         __convert_result_single_shot.
 
-        :param result: The result output from the Quantum Inspire backend with full-
-                       state projection histogram output.
+        :param result: The result output from the Quantum Inspire backend with full state projection histogram output.
         :param measurements: The measurement instance containing measurement information and measurement functionality.
 
         :return:
@@ -587,7 +585,7 @@ class QuantumInspireBackend(Backend):  # type: ignore
             the second result is a list with converted hexadecimal memory values for each shot.
         """
         raw_data_list = self.__api.get_raw_data_from_result(result['id'])
-        if raw_data_list:
+        if len(raw_data_list) > 0 and raw_data_list[0]:
             result_histogram_data, result_memory_data = self.__convert_result_multiple_shots(result, measurements,
                                                                                              raw_data_list)
         else:

--- a/src/tests/quantuminspire/qiskit/test_backend_qx.py
+++ b/src/tests/quantuminspire/qiskit/test_backend_qx.py
@@ -255,7 +255,7 @@ class TestQiSimulatorPy(unittest.TestCase):
         api.get_result_from_job.return_value = {'id': 1, 'histogram': [{'0': 0.5, '3': 0.5}],
                                                 'execution_time_in_seconds': 2.1, 'number_of_qubits': 2,
                                                 'raw_data_url': 'http://saevar-qutech-nginx/api/results/24/raw-data/'}
-        api.get_raw_data_from_result.return_value = []
+        api.get_raw_data_from_result.return_value = [[]]
         api.get_backend_type_by_name.return_value = {'max_number_of_shots': 4096}
         jobs = self._basic_job_dictionary
         measurements = Measurements.from_experiment(experiment)
@@ -298,7 +298,7 @@ class TestQiSimulatorPy(unittest.TestCase):
                                                     'execution_time_in_seconds': 2.1, 'number_of_qubits': 2,
                                                     'raw_data_url':
                                                         'http://saevar-qutech-nginx/api/results/24/raw-data/'}
-            api.get_raw_data_from_result.return_value = []
+            api.get_raw_data_from_result.return_value = [[]]
             jobs = self._basic_job_dictionary
             measurements = Measurements.from_experiment(experiment)
             user_data = simulator.generate_user_data(experiment, measurements)


### PR DESCRIPTION
* Assumed 'empty' raw data list was wrong. The multi measurement empty raw_data_list is [[]] instead of []
* Adjusted test cases
* Bug fixed. First check to see if there is a list of lists and then if the first list is filled with data