### PR TITLE
[SDS-808] Update GitHub actions versions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,24 +12,18 @@ jobs:
 
     steps:
     - name: Checkout Quantum Inspire SDK
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Clone Qiskit-terra
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: qiskit/qiskit-terra
         path: qiskit-terra
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: pip install prerequisites
-      uses: BSFishy/pip-action@v1
-      with:
-        packages: |
-          cython
-          ./qiskit-terra
-          .[dev]
-        upgrade: true
+      run: pip install --upgrade cython ./qiskit-terra .[dev]
     - name: Run examples
       run: |
         python ./docs/examples/example_qiskit_entangle.py

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -3,6 +3,7 @@ name: Nightly SDK build
 on:
   schedule:
     - cron: "59 23 * * 1-5"
+  push:
 
 jobs:
   test:


### PR DESCRIPTION
This PR updates the GitHub Actions versions. In addition:

* It replaces the outdated BSFishy/pip-action (not updated in the last 3 years) by a simple run.
* It adds a dependabot file to automatically update GitHub actions going forward.