### PR TITLE
[SDS-981] Argument type check

### DIFF
--- a/src/quantuminspire/qiskit/backend_qx.py
+++ b/src/quantuminspire/qiskit/backend_qx.py
@@ -132,6 +132,22 @@ class QuantumInspireBackend(Backend):  # type: ignore
     def backend_name(self) -> str:
         return self.name()  # type: ignore
 
+    @staticmethod
+    def strtobool(value: str) -> bool:
+        """Convert a string representation of truth to true (1) or false (0).
+        True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+        are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+        'val' is anything else.
+        From source code python 3.11.2 (distutils/util.py) which is deprecated from 3.12
+        """
+        val = value.lower()
+        if val in ('y', 'yes', 't', 'true', 'on', '1'):
+            return bool(1)
+        elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+            return bool(0)
+        else:
+            raise ValueError(f"invalid truth value {value}")
+
     def run(self,
             run_input: Union[QasmQobj, QuantumCircuit, List[QuantumCircuit]],
             shots: Optional[int] = None,
@@ -174,6 +190,9 @@ class QuantumInspireBackend(Backend):  # type: ignore
             qobj = run_input
         else:
             qobj = assemble(run_input, self, **run_config_dict)
+
+        if isinstance(allow_fsp, str):
+            allow_fsp = QuantumInspireBackend.strtobool(allow_fsp)
 
         number_of_shots = qobj.config.shots
         self.__validate_number_of_shots(number_of_shots)

--- a/src/tests/quantuminspire/qiskit/test_backend_qx.py
+++ b/src/tests/quantuminspire/qiskit/test_backend_qx.py
@@ -117,6 +117,22 @@ class TestQiSimulatorPy(unittest.TestCase):
         self.assertFalse(status.operational)
         self.assertEqual(status.pending_jobs, 0)
 
+    def test_strtobool(self):
+        simulator = QuantumInspireBackend(Mock(), Mock())
+        self.assertFalse(simulator.strtobool('False'))
+        self.assertFalse(simulator.strtobool('false'))
+        self.assertFalse(simulator.strtobool('0'))
+        self.assertFalse(simulator.strtobool('n'))
+        self.assertFalse(simulator.strtobool('no'))
+        self.assertTrue(simulator.strtobool('True'))
+        self.assertTrue(simulator.strtobool('true'))
+        self.assertTrue(simulator.strtobool('1'))
+        self.assertTrue(simulator.strtobool('y'))
+        self.assertTrue(simulator.strtobool('yes'))
+        with self.assertRaises(ValueError) as error:
+            simulator.strtobool('int')
+        self.assertEqual(("invalid truth value int",), error.exception.args)
+
     def test_run_a_circuit_returns_correct_result(self):
         api = Mock()
         type(api).__name__ = 'QuantumInspireAPI'

--- a/src/tests/quantuminspire/qiskit/test_backend_qx.py
+++ b/src/tests/quantuminspire/qiskit/test_backend_qx.py
@@ -508,7 +508,7 @@ class TestQiSimulatorPy(unittest.TestCase):
             result_experiment.assert_called_once_with(experiment, 25, ANY, project=project,
                                                       full_state_projection=True)
 
-    def test_fsp_flag_overridden_by_parameter(self):
+    def test_fsp_flag_overridden_by_string_parameter(self):
         with patch.object(QuantumInspireBackend, "_submit_experiment", return_value=Mock()) as result_experiment:
             api = Mock()
             project = {'id': 43}
@@ -522,7 +522,7 @@ class TestQiSimulatorPy(unittest.TestCase):
             qc.cx(0, 1)
             qc.x(0)
 
-            simulator.run(qc, 1000, allow_fsp=False)
+            simulator.run(qc, 1000, allow_fsp='False')
             experiment = self._circuit_to_experiment(qc)
             result_experiment.assert_called_once_with(experiment, 1000, ANY, project=project,
                                                       full_state_projection=False)
@@ -543,7 +543,7 @@ class TestQiSimulatorPy(unittest.TestCase):
             qc.cx(0, 1)
             qc.x(0)
 
-            simulator.run(qc, 25)
+            simulator.run(qc, 25, allow_fsp=True)
             experiment = self._circuit_to_experiment(qc)
         result_experiment.assert_called_once_with(experiment, 25, ANY, project=project,
                                                   full_state_projection=False)


### PR DESCRIPTION
* Convert `device dependent` run-parameter allow_fsp to bool when it is a string (used the strtobool implementation distutils)
